### PR TITLE
VectorSerializer: switch to style array

### DIFF
--- a/src/serializer/VectorSerializer.js
+++ b/src/serializer/VectorSerializer.js
@@ -109,6 +109,11 @@ export class VectorSerializer extends BaseSerializer {
         }
       }
 
+      // assumption below: styles is an array of OlStyleStyle
+      if (styles instanceof OlStyleStyle) {
+        styles = [styles];
+      }
+
       if (styles) {
         serializedFeatures.push(serializedFeature);
 


### PR DESCRIPTION
This PR adds a check for `styles` to `VectorSerializer` if `styleFunction` returns a single instance of `OlStyleStyle`.

As the serializer assumes that styles is an array of `OlStyleStyle` it is simply creates one here.