### PR TITLE
Fix `transformOpts` assignment for `OlInteractionTransform`

### DIFF
--- a/dist/manager/BaseMapFishPrintManager.js
+++ b/dist/manager/BaseMapFishPrintManager.js
@@ -5,6 +5,8 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.BaseMapFishPrintManager = undefined;
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 var _map = require('ol/map');
 
 var _map2 = _interopRequireDefault(_map);
@@ -328,7 +330,7 @@ var BaseMapFishPrintManager = exports.BaseMapFishPrintManager = function (_Obser
 
     _this.initTransformInteraction = function () {
       if (_Shared2.default.getInteractionsByName(_this.map, _this.constructor.TRANSFORM_INTERACTION_NAME).length === 0) {
-        var transform = new (Function.prototype.bind.apply(_InteractionTransform2.default, [null].concat([{
+        var transform = new _InteractionTransform2.default(_extends({
           features: [_this._extentFeature],
           translateFeature: true,
           translate: true,
@@ -336,7 +338,7 @@ var BaseMapFishPrintManager = exports.BaseMapFishPrintManager = function (_Obser
           scale: true,
           rotate: true,
           keepAspectRatio: true
-        }], _toConsumableArray(_this.transformOpts))))();
+        }, _this.transformOpts));
 
         transform.set('name', _this.constructor.TRANSFORM_INTERACTION_NAME);
 

--- a/src/manager/BaseMapFishPrintManager.js
+++ b/src/manager/BaseMapFishPrintManager.js
@@ -405,8 +405,9 @@ export class BaseMapFishPrintManager extends Observable {
         stretch: false,
         scale: true,
         rotate: true,
-        keepAspectRatio: true
-      }, ...this.transformOpts);
+        keepAspectRatio: true,
+        ...this.transformOpts
+      });
 
       transform.set('name', this.constructor.TRANSFORM_INTERACTION_NAME);
 


### PR DESCRIPTION
This fix enables to overwrite default options defined for `OlInteractionTransform` by passing of `transformOpts` object during manager initialization.

```javascript
const manager = new MapFishPrintV2Manager({
      url: 'http://url.com',
      map: map,
      ... 
      transformOpts: {
        rotate: false,
        scale: false
        ...
      }
    });
```

~~Additionally some dependencies were bumped to newer versions.~~ -> see #8

Please review @dnlkoch 