### PR TITLE
Update to `webpack` version 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "ol": "4.6.5",
     "rimraf": "2.6.2",
     "webpack": "4.8.3",
+    "webpack-cli": "2.1.4",
     "webpack-dev-server": "3.1.4",
     "webpack-merge": "4.1.2"
   }

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -11,10 +11,10 @@ module.exports = {
   },
 
   module: {
-    loaders: [{
+    rules: [{
       test: /\.js?$/,
       exclude: /node_modules/,
-      loader: 'babel-loader'
+      use: 'babel-loader'
     }]
   }
 };


### PR DESCRIPTION
Since `greenkeeper` was enabled for the project it has updated a webpack dependency to version 4.x (#9). So we have to adapt some configs to match changed API now.

Please review @dnlkoch 