### PR TITLE
Adapt event handler function names to match OL5 API

### DIFF
--- a/src/interaction/InteractionTransform.js
+++ b/src/interaction/InteractionTransform.js
@@ -455,7 +455,7 @@ export class OlInteractionTransform extends OlInteractionPointer {
    * @param {ol.MapBrowserEvent} evt Map browser event.
    * @return {boolean} `true` to start the drag sequence.
    */
-  handleDownEvent_ = function(evt) {
+  handleDownEvent = function(evt) {
     var sel = this.getFeatureAtPixel_(evt.pixel);
     var feature = sel.feature;
 
@@ -506,7 +506,7 @@ export class OlInteractionTransform extends OlInteractionPointer {
   /**
    * @param {ol.MapBrowserEvent} evt Map browser event.
    */
-  handleDragEvent_ = function(evt) {
+  handleDragEvent = function(evt) {
     var geometry;
 
     switch (this.mode_) {
@@ -603,7 +603,7 @@ export class OlInteractionTransform extends OlInteractionPointer {
   /**
    * @param {ol.MapBrowserEvent} evt Event.
    */
-  handleMoveEvent_ = function(evt) {
+  handleMoveEvent = function(evt) {
     if (!this.mode_) {
       var sel = this.getFeatureAtPixel_(evt.pixel);
       var element = evt.map.getTargetElement();
@@ -629,7 +629,7 @@ export class OlInteractionTransform extends OlInteractionPointer {
    * @param {ol.MapBrowserEvent} evt Map browser event.
    * @return {boolean} `false` to stop the drag sequence.
    */
-  handleUpEvent_ = function() {
+  handleUpEvent = function() {
     this.dispatchEvent({
       type: this.mode_ + 'end',
       feature: this.feature_,


### PR DESCRIPTION
Handler names for `up`, `down`, `drag` and `move` events within [`ol/interaction/Pointer`](https://github.com/openlayers/openlayers/blob/master/src/ol/interaction/Pointer.js) don't end with underscore in `ol5` as they did in `ol4` any more.

E.g. compare [`ol4`](https://github.com/openlayers/openlayers/blob/v4.6.5/src/ol/interaction/pointer.js#L41)  vs. [`ol5`](https://github.com/openlayers/openlayers/blob/master/src/ol/interaction/Pointer.js#L57).

This MR removes underscores and thus restores transform interaction functionality while operating with ol5.

Please review @dnlkoch 