### PR TITLE
Make capabilites endpoint configurable

### DIFF
--- a/src/manager/BaseMapFishPrintManager.js
+++ b/src/manager/BaseMapFishPrintManager.js
@@ -137,6 +137,14 @@ export class BaseMapFishPrintManager extends Observable {
   legendFilter = () => true;
 
   /**
+   * Whether the default print capabilities endpoint (commonly `info.json`)
+   * should be used.
+   * If set to false, the mapfish manager has to be initialized with URL
+   * to configured capabilities endpoint. Default is true.
+   */
+  useDefaultJsonEndpoint = true;
+
+  /**
    * The supported layouts by the print service.
    *
    * @type {Array}
@@ -235,7 +243,7 @@ export class BaseMapFishPrintManager extends Observable {
       'or `capabilities`.');
     }
 
-    if (this.url && this.url.split('/').pop()) {
+    if (this.url && this.url.split('/').pop() && this.useDefaultJsonEndpoint) {
       this.url += '/';
     }
   }

--- a/src/manager/MapFishPrintV2Manager.js
+++ b/src/manager/MapFishPrintV2Manager.js
@@ -59,7 +59,11 @@ export class MapFishPrintV2Manager extends BaseMapFishPrintManager {
    * @return {Promise}
    */
   loadCapabilities = () => {
-    return fetch(this.url + this.constructor.INFO_JSON_ENDPOINT, {
+    let url = this.url;
+    if (this.useDefaultJsonEndpoint) {
+      url += this.constructor.INFO_JSON_ENDPOINT;
+    }
+    return fetch(url, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
Previously manager always used default mapfish print capabilities endpoint ending with `info.json`.

This PR changes this and let user configure the manager with flag `useDefaultJsonEndpointer` to decide, if custom capabilities URL should be used instead of default.

The default value `useDefaultJsonEndpointer` is set to `true` to ensure backward compatibility.

Please review @dnlkoch 