### PR TITLE
Reverse layer ordering for MapFish print v3

### DIFF
--- a/src/manager/BaseMapFishPrintManager.js
+++ b/src/manager/BaseMapFishPrintManager.js
@@ -154,6 +154,13 @@ export class BaseMapFishPrintManager extends Observable {
   customPrintScales = [];
 
   /**
+   * Default timeout in ms after which print job polling will be canceled.
+   *
+   * @type {number}
+   */
+  timeout = 5000;
+
+  /**
    * The supported layouts by the print service.
    *
    * @type {Array}

--- a/src/manager/MapFishPrintV3Manager.js
+++ b/src/manager/MapFishPrintV3Manager.js
@@ -366,7 +366,7 @@ export class MapFishPrintV3Manager extends BaseMapFishPrintManager {
           acc.push(serializedLayer);
         }
         return acc;
-      }, []);
+      }, []).reverse();
 
     const serializedLegends = mapLayers
       .filter(this.filterPrintableLegend.bind(this))
@@ -376,7 +376,7 @@ export class MapFishPrintV3Manager extends BaseMapFishPrintManager {
           acc.push(serializedLegend);
         }
         return acc;
-      }, []);
+      }, []).reverse();
 
     const payload = {
       layout: this.getLayout().name,

--- a/src/manager/MapFishPrintV3Manager.js
+++ b/src/manager/MapFishPrintV3Manager.js
@@ -72,13 +72,6 @@ export class MapFishPrintV3Manager extends BaseMapFishPrintManager {
   _printJobReference = null;
 
   /**
-   * Default timeout in ms after which print job polling will be canceled.
-   *
-   * @type {number}
-   */
-  timeout = 5000;
-
-  /**
    * The constructor
    */
   constructor() {


### PR DESCRIPTION
Title says it all.

In addition, timeout property was moved to `BaseMapFishPrintManager`