### PR TITLE
Add support for `longitudeFirst` parameter

### DIFF
--- a/src/manager/MapFishPrintV3Manager.js
+++ b/src/manager/MapFishPrintV3Manager.js
@@ -387,7 +387,8 @@ export class MapFishPrintV3Manager extends BaseMapFishPrintManager {
           layers: serializedLayers,
           projection: mapProjection.getCode(),
           rotation: this.calculateRotation() || 0,
-          scale: this.getScale()
+          scale: this.getScale(),
+          longitudeFirst: mapProjection.getUnits() !== 'm',
           // TODO Add support for customizable map attribute params,
           // e.g. zoomToFeatures, see http://mapfish.github.io/mapfish-print-doc/attributes.html#!map
         },


### PR DESCRIPTION
Adds support for `longitudeFirst` configuration parameter which is useful while printing of maps with non-metric based projections (e.g. EPSG:4326) with mapfish v3.

Please review @terrestris/devs 