### PR TITLE
Add support for customizable map parameters for mapfish v3

### DIFF
--- a/src/manager/BaseMapFishPrintManager.js
+++ b/src/manager/BaseMapFishPrintManager.js
@@ -104,34 +104,6 @@ export class BaseMapFishPrintManager extends Observable {
   customParams = {};
 
   /**
-   * Custom parameters which can be additionally set on map to determine its
-   * special handling while printing.
-   *
-   * The list of allowed properties is as follows:
-   *  * areaOfInterest
-   *  * bbox
-   *  * center
-   *  * rotation
-   *  * scale
-   *  * useNearestScale
-   *  * dpiSensitiveStyle
-   *  * useAdjustBounds
-   *  * layers
-   *  * width
-   *  * longitudeFirst
-   *  * projection
-   *  * dpi
-   *  * zoomToFeatures
-   *  * height
-   *
-   * Please refer to http://mapfish.github.io/mapfish-print-doc/attributes.html#!map
-   * for further details.
-   *
-   * @type {Object}
-   */
-  customMapParams = {};
-
-  /**
    * The layer to show the actual print extent on. If not provided, a default
    * one will be created.
    *

--- a/src/manager/BaseMapFishPrintManager.js
+++ b/src/manager/BaseMapFishPrintManager.js
@@ -104,6 +104,34 @@ export class BaseMapFishPrintManager extends Observable {
   customParams = {};
 
   /**
+   * Custom parameters which can be additionally set on map to determine its
+   * special handling while printing.
+   *
+   * The list of allowed properties is as follows:
+   *  * areaOfInterest
+   *  * bbox
+   *  * center
+   *  * rotation
+   *  * scale
+   *  * useNearestScale
+   *  * dpiSensitiveStyle
+   *  * useAdjustBounds
+   *  * layers
+   *  * width
+   *  * longitudeFirst
+   *  * projection
+   *  * dpi
+   *  * zoomToFeatures
+   *  * height
+   *
+   * Please refer to http://mapfish.github.io/mapfish-print-doc/attributes.html#!map
+   * for further details.
+   *
+   * @type {Object}
+   */
+  customMapParams = {};
+
+  /**
    * The layer to show the actual print extent on. If not provided, a default
    * one will be created.
    *

--- a/src/manager/MapFishPrintV3Manager.js
+++ b/src/manager/MapFishPrintV3Manager.js
@@ -47,6 +47,38 @@ export class MapFishPrintV3Manager extends BaseMapFishPrintManager {
   ];
 
   /**
+   * Custom parameters which can be additionally set on map to determine its
+   * special handling while printing.
+   *
+   * The list of all allowed properties is as follows:
+   *  * center (default)
+   *  * dpi (default)
+   *  * layers (default)
+   *  * projection (default)
+   *  * rotation (default)
+   *  * scale (default)
+   *  * areaOfInterest
+   *  * bbox
+   *  * useNearestScale
+   *  * dpiSensitiveStyle
+   *  * useAdjustBounds
+   *  * width
+   *  * longitudeFirst
+   *  * zoomToFeatures
+   *  * height
+   *
+   * Note: Properties marked as default will be handled by the manager itself
+   * and don't need to be explicitly provided as customized params (s.
+   * https://github.com/terrestris/mapfish-print-manager/blob/master/src/manager/MapFishPrintV3Manager.js#L416)
+   *
+   * Please refer to http://mapfish.github.io/mapfish-print-doc/attributes.html#!map
+   * for further details.
+   *
+   * @type {Object}
+   */
+  customMapParams = {};
+
+  /**
    * The supported print applications by the print service.
    *
    * @type {Array}

--- a/src/manager/MapFishPrintV3Manager.js
+++ b/src/manager/MapFishPrintV3Manager.js
@@ -116,7 +116,7 @@ export class MapFishPrintV3Manager extends BaseMapFishPrintManager {
     // mapfish3 doesn't provide scales via capabilities, so we get them from
     // initialized manager if set or set some most common used values here
     // manually as fallback
-    if (this.customPrintScales) {
+    if (this.customPrintScales.length > 0) {
       this._scales = this.customPrintScales;
     } else {
       this._scales = scales;
@@ -387,9 +387,8 @@ export class MapFishPrintV3Manager extends BaseMapFishPrintManager {
           layers: serializedLayers,
           projection: mapProjection.getCode(),
           rotation: this.calculateRotation() || 0,
-          scale: this.getScale()
-          // TODO Add support for customizable map attribute params,
-          // e.g. zoomToFeatures, see http://mapfish.github.io/mapfish-print-doc/attributes.html#!map
+          scale: this.getScale(),
+          ...this.customMapParams
         },
         legend: {
           classes: serializedLegends


### PR DESCRIPTION
Allow user to provide some custom map parameters which can be interpreted by mapfish v3 while printing.

The whole list of parameters is defined under http://mapfish.github.io/mapfish-print-doc/attributes.html#!map (section "Inputs").

Additionally fix setting of user defined print scales for manager v3 (previously fallback value could never be used since `customPrintScales` will be instantiated as empty array initially and always defined).

Please review @dnlkoch 