### PR TITLE
Upgrade to OpenLayers v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Install needed dependencies and start `webpack` devServer with
 
 ```
 npm i
-npm run start
+npm start
 ```
 
 Now just try out the example applications:

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "parse-css-font": "4.0.0"
   },
   "peerDependencies": {
-    "ol": "~5.0"
+    "ol": "~6.0"
   },
   "devDependencies": {
     "@babel/cli": "7.7.7",
@@ -67,7 +67,7 @@
     "jest": "24.7.1",
     "jest-fetch-mock": "3.0.1",
     "np": "5.2.1",
-    "ol": "5.3.3",
+    "ol": "6.0.1",
     "rimraf": "3.0.0",
     "webpack": "4.41.5",
     "webpack-cli": "3.3.10",

--- a/spec/serializer/MapFishPrintV2VectorSerializer.spec.js
+++ b/spec/serializer/MapFishPrintV2VectorSerializer.spec.js
@@ -143,10 +143,10 @@ describe('MapFishPrintV2VectorSerializer', () => {
       image: new OlStyleCircle({
         radius: 5,
         fill: new OlStyleFill({
-          color: 'black'
+          color: '#000'
         }),
         stroke: new OlStyleStroke({
-          color: 'gray'
+          color: '#808080'
         })
       }),
       fill: new OlStyleFill({

--- a/src/manager/BaseMapFishPrintManager.js
+++ b/src/manager/BaseMapFishPrintManager.js
@@ -320,8 +320,8 @@ export class BaseMapFishPrintManager extends Observable {
         })
       });
 
-      extentLayer.on('precompose', this.onExtentLayerPreCompose.bind(this));
-      extentLayer.on('postcompose', this.onExtentLayerPostCompose.bind(this));
+      extentLayer.on('prerender', this.onExtentLayerPreRender.bind(this));
+      extentLayer.on('postrender', this.onExtentLayerPostRender.bind(this));
 
       this.extentLayer = extentLayer;
 
@@ -333,21 +333,21 @@ export class BaseMapFishPrintManager extends Observable {
   }
 
   /**
-   * Called on the extentLayer's `precompose` event.
+   * Called on the extentLayer's `prerender` event.
    *
    * @param {ol.render.Event} olEvt The ol render event.
    */
-  onExtentLayerPreCompose(olEvt) {
+  onExtentLayerPreRender(olEvt) {
     const ctx = olEvt.context;
     ctx.save();
   }
 
   /**
-   * Called on the extentLayer's `postcompose` event.
+   * Called on the extentLayer's `postrender` event.
    *
    * @param {ol.render.Event} olEvt The ol render event.
    */
-  onExtentLayerPostCompose(olEvt) {
+  onExtentLayerPostRender(olEvt) {
     const ctx = olEvt.context;
     const canvas = ctx.canvas;
     const width = canvas.width;

--- a/src/serializer/MapFishPrintV2VectorSerializer.js
+++ b/src/serializer/MapFishPrintV2VectorSerializer.js
@@ -293,7 +293,6 @@ export class MapFishPrintV2VectorSerializer extends BaseSerializer {
       rotateWithView: olCircleStyle.getRotateWithView(),
       rotation: olCircleStyle.getRotation(),
       scale: olCircleStyle.getScale(),
-      snapToPixel: olCircleStyle.getSnapToPixel(),
       stroke: this.writeStrokeStyle(olCircleStyle.getStroke())
     };
   }
@@ -322,7 +321,6 @@ export class MapFishPrintV2VectorSerializer extends BaseSerializer {
       rotation: olIconStyle.getRotation(),
       scale: olIconStyle.getScale(),
       size: olIconStyle.getSize(),
-      snapToPixel: olIconStyle.getSnapToPixel(),
       src: olIconStyle.getSrc()
     };
   }
@@ -351,7 +349,6 @@ export class MapFishPrintV2VectorSerializer extends BaseSerializer {
       rotateWithView: olRegularShape.getRotateWithView(),
       rotation: olRegularShape.getRotation(),
       scale: olRegularShape.getScale(),
-      snapToPixel: olRegularShape.getSnapToPixel(),
       stroke: this.writeStrokeStyle(olRegularShape.getStroke())
     };
   }

--- a/src/serializer/MapFishPrintV3GeoJsonSerializer.js
+++ b/src/serializer/MapFishPrintV3GeoJsonSerializer.js
@@ -306,7 +306,6 @@ export class MapFishPrintV3GeoJsonSerializer extends BaseSerializer {
       rotateWithView: olCircleStyle.getRotateWithView(),
       rotation: olCircleStyle.getRotation(),
       scale: olCircleStyle.getScale(),
-      snapToPixel: olCircleStyle.getSnapToPixel(),
       stroke: this.writeStrokeStyle(olCircleStyle.getStroke())
     };
   }
@@ -335,7 +334,6 @@ export class MapFishPrintV3GeoJsonSerializer extends BaseSerializer {
       rotation: olIconStyle.getRotation(),
       scale: olIconStyle.getScale(),
       size: olIconStyle.getSize(),
-      snapToPixel: olIconStyle.getSnapToPixel(),
       src: olIconStyle.getSrc()
     };
   }
@@ -364,7 +362,6 @@ export class MapFishPrintV3GeoJsonSerializer extends BaseSerializer {
       rotateWithView: olRegularShape.getRotateWithView(),
       rotation: olRegularShape.getRotation(),
       scale: olRegularShape.getScale(),
-      snapToPixel: olRegularShape.getSnapToPixel(),
       stroke: this.writeStrokeStyle(olRegularShape.getStroke())
     };
   }


### PR DESCRIPTION
## BREAKING CHANGE

Upgrade to `ol` version 6.x considering [release notes](https://github.com/openlayers/openlayers/releases/tag/v6.0.0) for release 6.0.0.

Please review @terrestris/devs 