### PR TITLE
Use query-string and url-parse for basepath detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5666,8 +5666,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "decompress-response": {
       "version": "4.2.1",
@@ -8384,7 +8383,25 @@
             "prepend-http": "^1.0.0",
             "query-string": "^4.1.0",
             "sort-keys": "^1.0.0"
+          },
+          "dependencies": {
+            "query-string": {
+              "version": "4.3.4",
+              "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+              "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+              "dev": true,
+              "requires": {
+                "object-assign": "^4.1.0",
+                "strict-uri-encode": "^1.0.0"
+              }
+            }
           }
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+          "dev": true
         }
       }
     },
@@ -12710,13 +12727,13 @@
       "dev": true
     },
     "query-string": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-      "dev": true,
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.10.1.tgz",
+      "integrity": "sha512-SHTUV6gDlgMXg/AQUuLpTiBtW/etZ9JT6k6RCtCyqADquApLX0Aq5oK/s5UeTUAWBG50IExjIr587GqfXRfM4A==",
       "requires": {
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
       }
     },
     "querystring": {
@@ -12734,8 +12751,7 @@
     "querystringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
-      "dev": true
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
     "quick-lru": {
       "version": "1.1.0",
@@ -13227,8 +13243,7 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.14.1",
@@ -14043,6 +14058,11 @@
         "through": "2"
       }
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -14217,10 +14237,9 @@
       "dev": true
     },
     "strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-length": {
       "version": "2.0.0",
@@ -15286,7 +15305,6 @@
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
       "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
-      "dev": true,
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     "js-logger": "^1.6.0",
     "lodash": "^4.17.15",
     "parse-color": "^1.0.0",
-    "parse-css-font": "^4.0.0"
+    "parse-css-font": "^4.0.0",
+    "query-string": "^6.8.2",
+    "url-parse": "^1.4.7"
   },
   "peerDependencies": {
     "ol": "^6.0"

--- a/spec/manager/MapFishPrintV3Manager.spec.js
+++ b/spec/manager/MapFishPrintV3Manager.spec.js
@@ -100,4 +100,15 @@ describe('MapFishPrintV3Manager', () => {
         fetch.resetMocks();
       });
   });
+
+  describe('#getBasePath', () => {
+    it('is defined', () => {
+      const manager = new MapFishPrintV3Manager({
+        map: testMap,
+        url: 'https://mock:8080/print/pdf/'
+      });
+      expect(manager.getBasePath).not.toBeUndefined();
+    });
+  });
+1
 });

--- a/spec/manager/MapFishPrintV3Manager.spec.js
+++ b/spec/manager/MapFishPrintV3Manager.spec.js
@@ -110,5 +110,5 @@ describe('MapFishPrintV3Manager', () => {
       expect(manager.getBasePath).not.toBeUndefined();
     });
   });
-1
+
 });

--- a/src/manager/MapFishPrintV3Manager.js
+++ b/src/manager/MapFishPrintV3Manager.js
@@ -1,4 +1,6 @@
 import get from 'lodash/get';
+import URL from 'url-parse';
+import QueryString from 'query-string';
 import {
   getCenter
 } from 'ol/extent';
@@ -243,6 +245,16 @@ export class MapFishPrintV3Manager extends BaseMapFishPrintManager {
   }
 
   /**
+   * Determine the base path the application is running
+   * @return {string} The base host path
+   */
+  getBasePath() {
+    const baseUrlObj = new URL(this.url, null, QueryString.parse);
+    const baseHost = `${baseUrlObj.protocol}//${baseUrlObj.host}${baseUrlObj.pathname}`;
+    return baseHost;
+  }
+
+  /**
    *
    *
    * @param {boolean} forceDownload
@@ -275,25 +287,17 @@ export class MapFishPrintV3Manager extends BaseMapFishPrintManager {
           statusURL
         } = json;
 
-        // get absolute url of print status and download to ensure we will be
-        // redirected correctly while printing
-        const matches = this.url.match(/[^/](\/[^/].*)/);
-        let baseHost = '';
-        if (matches && matches[1]) {
-          const idx = this.url.indexOf(matches[1]);
-          baseHost = this.url.substring(0, idx);
-        }
-
+        const basePath = this.getBasePath();
         this._printJobReference = ref;
 
-        return this.pollUntilDone.call(this, baseHost + statusURL, 1000, this.timeout)
+        return this.pollUntilDone.call(this, basePath + statusURL, 1000, this.timeout)
           .then(downloadUrl => {
             this._printJobReference = null;
 
             if (forceDownload) {
-              this.download(baseHost + downloadUrl);
+              this.download(basePath + downloadUrl);
             } else {
-              return Promise.resolve(baseHost + downloadUrl);
+              return Promise.resolve(basePath + downloadUrl);
             }
           })
           .catch(error => {

--- a/src/manager/MapFishPrintV3Manager.js
+++ b/src/manager/MapFishPrintV3Manager.js
@@ -250,7 +250,7 @@ export class MapFishPrintV3Manager extends BaseMapFishPrintManager {
    */
   getBasePath() {
     const baseUrlObj = new URL(this.url, null, QueryString.parse);
-    const baseHost = `${baseUrlObj.protocol}//${baseUrlObj.host}${baseUrlObj.pathname}`;
+    const baseHost = `${baseUrlObj.protocol}//${baseUrlObj.host}${baseUrlObj.port ? ':' + baseUrlObj.port : ''}${baseUrlObj.pathname}`;
     return baseHost;
   }
 


### PR DESCRIPTION
Currently, the determination of `basePath`  / `baseHost` doesn't work properly for relative URLs that reference an endpoint more than two levels above to the application that uses  `mapfish-print-manager`. 

This PR introduces usage of `query-string` and `url-parse` for its proper detection.

Pltz review @terrestris/devs 