### PR TITLE
Use query-string and url-parse for basepath detection - V5.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     "js-logger": "1.6.0",
     "lodash": "4.17.11",
     "parse-color": "1.0.0",
-    "parse-css-font": "4.0.0"
+    "parse-css-font": "4.0.0",
+    "query-string": "6.8.2",
+    "url-parse": "1.4.7"
   },
   "peerDependencies": {
     "ol": "~5.0"

--- a/spec/manager/MapFishPrintV3Manager.spec.js
+++ b/spec/manager/MapFishPrintV3Manager.spec.js
@@ -100,4 +100,15 @@ describe('MapFishPrintV3Manager', () => {
         fetch.resetMocks();
       });
   });
+
+  describe('#getBasePath', () => {
+    it('is defined', () => {
+      const manager = new MapFishPrintV3Manager({
+        map: testMap,
+        url: 'https://mock:8080/print/pdf/'
+      });
+      expect(manager.getBasePath).not.toBeUndefined();
+    });
+
+  });
 });

--- a/src/manager/MapFishPrintV3Manager.js
+++ b/src/manager/MapFishPrintV3Manager.js
@@ -1,3 +1,5 @@
+import URL from 'url-parse';
+import QueryString from 'query-string';
 import get from 'lodash/get';
 import {
   getCenter
@@ -243,6 +245,16 @@ export class MapFishPrintV3Manager extends BaseMapFishPrintManager {
   }
 
   /**
+   * Determine the base path the application is running
+   * @return {string} The base host path
+   */
+  getBasePath() {
+    const baseUrlObj = new URL(this.url, null, QueryString.parse);
+    const baseHost = `${baseUrlObj.protocol}//${baseUrlObj.host}${baseUrlObj.pathname}`;
+    return baseHost;
+  }
+
+  /**
    *
    *
    * @param {boolean} forceDownload
@@ -275,25 +287,18 @@ export class MapFishPrintV3Manager extends BaseMapFishPrintManager {
           statusURL
         } = json;
 
-        // get absolute url of print status and download to ensure we will be
-        // redirected correctly while printing
-        const matches = this.url.match(/[^/](\/[^/].*)/);
-        let baseHost = '';
-        if (matches && matches[1]) {
-          const idx = this.url.indexOf(matches[1]);
-          baseHost = this.url.substring(0, idx);
-        }
+        const basePath = this.getBasePath();
 
         this._printJobReference = ref;
 
-        return this.pollUntilDone.call(this, baseHost + statusURL, 1000, this.timeout)
+        return this.pollUntilDone.call(this, basePath + statusURL, 1000, this.timeout)
           .then(downloadUrl => {
             this._printJobReference = null;
 
             if (forceDownload) {
-              this.download(baseHost + downloadUrl);
+              this.download(basePath + downloadUrl);
             } else {
-              return Promise.resolve(baseHost + downloadUrl);
+              return Promise.resolve(basePath + downloadUrl);
             }
           })
           .catch(error => {

--- a/src/manager/MapFishPrintV3Manager.js
+++ b/src/manager/MapFishPrintV3Manager.js
@@ -250,7 +250,7 @@ export class MapFishPrintV3Manager extends BaseMapFishPrintManager {
    */
   getBasePath() {
     const baseUrlObj = new URL(this.url, null, QueryString.parse);
-    const baseHost = `${baseUrlObj.protocol}//${baseUrlObj.host}${baseUrlObj.pathname}`;
+    const baseHost = `${baseUrlObj.protocol}//${baseUrlObj.host}${baseUrlObj.port ? ':' + baseUrlObj.port : ''}${baseUrlObj.pathname}`;
     return baseHost;
   }
 


### PR DESCRIPTION
Currently, the determination of `basePath`  / `baseHost` doesn't work properly for relative URLs that reference an endpoint more than two levels above to the application that uses  `mapfish-print-manager`. 

This PR introduces usage of `query-string` and `url-parse` for its proper detection.

:exclamation: This tackles V5 of  `mapfish-print-manager` using OpenLayers 5. Therefore, a new branch `ol5` was created as base for merge.

Pltz review @terrestris/devs 