### PR TITLE
remove duplicated port from base url detection

### DIFF
--- a/src/manager/MapFishPrintV3Manager.js
+++ b/src/manager/MapFishPrintV3Manager.js
@@ -250,7 +250,7 @@ export class MapFishPrintV3Manager extends BaseMapFishPrintManager {
    */
   getBasePath() {
     const baseUrlObj = new URL(this.url, null, QueryString.parse);
-    const baseHost = `${baseUrlObj.protocol}//${baseUrlObj.host}${baseUrlObj.port ? ':' + baseUrlObj.port : ''}${baseUrlObj.pathname}`;
+    const baseHost = `${baseUrlObj.protocol}//${baseUrlObj.host}${baseUrlObj.pathname}`;
     return baseHost;
   }
 


### PR DESCRIPTION
 `URL.host` already contains both hostname and port if present. Currently the port was included twice because of this (e.g. `https://localhost:9090:9090/print/`)

This just restores the version initially proposed in https://github.com/terrestris/mapfish-print-manager/pull/295

@devs Please review