### PR TITLE
Enable custom static legend graphic sources

### DIFF
--- a/src/util/Shared.js
+++ b/src/util/Shared.js
@@ -69,6 +69,11 @@ export class Shared {
   static getLegendGraphicUrl = layer => {
     if (layer.getSource() instanceof OlSourceTileWMS ||
       layer.getSource() instanceof OlSourceImageWMS) {
+
+      if (layer.get('legendUrl')) {
+        return layer.get('legendUrl');
+      }
+
       const customParams = layer.get('customPrintLegendParams');
       const source = layer.getSource();
       const {


### PR DESCRIPTION
Check if layer has property `legendGraphic` which contains the URL to a customized legend graphic and, if set, return it instead of `GetLegendGraphic` request URL.

Please review @terrestris/devs 