### PR TITLE
Fix double slashes in urls

### DIFF
--- a/spec/util/Shared.spec.js
+++ b/spec/util/Shared.spec.js
@@ -321,4 +321,23 @@ describe('Shared', () => {
       expect(Shared.getScaleForResolution(100, 'degrees')).toEqual(39712375676.76163);
     });
   });
+
+  describe('#sanitizeUrl', () => {
+    it('is defined', () => {
+      expect(Shared.sanitizeUrl).toBeDefined();
+    });
+
+    it('removes doubled forward slashes from url', () => {
+      const wrongUrl1 = 'https://///www.terrestris.de/welcome//to//us/';
+      const wrongUrl2 = 'https://///www.terrestris.de/welcome////to//us//';
+      const wrongUrl3 = 'https:///www.terrestris.de/welcome////to//us////';
+      const goodUrl = 'https://www.terrestris.de/welcome/to/us';
+      const sanitizedUrl = 'https://www.terrestris.de/welcome/to/us';
+
+      expect(Shared.sanitizeUrl(wrongUrl1)).toEqual(sanitizedUrl);
+      expect(Shared.sanitizeUrl(wrongUrl2)).toEqual(sanitizedUrl);
+      expect(Shared.sanitizeUrl(wrongUrl3)).toEqual(sanitizedUrl);
+      expect(Shared.sanitizeUrl(goodUrl)).toEqual(sanitizedUrl);
+    });
+  });
 });

--- a/src/manager/MapFishPrintV3Manager.js
+++ b/src/manager/MapFishPrintV3Manager.js
@@ -290,9 +290,10 @@ export class MapFishPrintV3Manager extends BaseMapFishPrintManager {
         } = json;
 
         const basePath = this.getBasePath();
+        const fullStatusUrl = Shared.sanitizeUrl(basePath + statusURL);
         this._printJobReference = ref;
 
-        return this.pollUntilDone.call(this, basePath + statusURL, 1000, this.timeout)
+        return this.pollUntilDone.call(this, fullStatusUrl, 1000, this.timeout)
           .then(downloadUrl => {
             this._printJobReference = null;
 

--- a/src/util/Shared.js
+++ b/src/util/Shared.js
@@ -123,6 +123,15 @@ export class Shared {
 
     return parseFloat(resolution) * mpu * inchesPerMeter * dpi;
   }
+
+  /**
+   * Removes duplicated forward slashes as well as trailing slash
+   * and returns normalized URL string
+   * @param {*} url
+   */
+  static sanitizeUrl = (url) => {
+    return url.replace(/([^:]\/)\/+/g, '$1').replace(/\/+$/, '');
+  }
 }
 
 export default Shared;


### PR DESCRIPTION
Avoid dublicated slashes in URL strings which can possibly lead to request aborting

e.g. `https://localhost:9090/print/default//status/status-hash.json` should become `https://localhost:9090/print/default/status/status-hash.json`

@terrestris/devs 