### PR TITLE
Remove unsupported layer attributes

### DIFF
--- a/src/serializer/BaseSerializer.js
+++ b/src/serializer/BaseSerializer.js
@@ -1,4 +1,3 @@
-import Shared from '../util/Shared';
 import Log from '../util/Logger';
 
 /**
@@ -14,31 +13,6 @@ export class BaseSerializer {
    * @type {Array}
    */
   static sourceCls = [];
-
-  /**
-   * Serializes/Encodes the given layer.
-   *
-   * @param {ol.layer.Layer} layer The layer to serialize/encode.
-   * @return {Object} The serialized/encoded layer.
-   */
-  serialize(layer) {
-    const serialized = {};
-    const source = layer.getSource();
-    const units = source.getProjection() ?
-      source.getProjection().getUnits() :
-      'm';
-
-    if (layer.getMinResolution() > 0) {
-      serialized.minScaleDenominator = Shared.getScaleForResolution(
-        layer.getMinResolution(), units);
-    }
-    if (layer.getMaxResolution() !== Infinity) {
-      serialized.maxScaleDenominator = Shared.getScaleForResolution(
-        layer.getMaxResolution(), units);
-    }
-
-    return serialized;
-  }
 
   /**
    * Validates if the given ol source is compatible with the serializer. Usally

--- a/src/serializer/MapFishPrintV2VectorSerializer.js
+++ b/src/serializer/MapFishPrintV2VectorSerializer.js
@@ -138,7 +138,6 @@ export class MapFishPrintV2VectorSerializer extends BaseSerializer {
     });
 
     const serialized = {
-      ...super.serialize(layer, source),
       ...{
         name: layer.get('name') || 'Vector Layer',
         opacity: layer.getOpacity(),

--- a/src/serializer/MapFishPrintV2WMSSerializer.js
+++ b/src/serializer/MapFishPrintV2WMSSerializer.js
@@ -66,7 +66,6 @@ export class MapFishPrintV2WMSSerializer extends BaseSerializer {
     } = source.getParams();
 
     const serialized = {
-      ...super.serialize(layer, source),
       ...{
         baseURL: source instanceof OlSourceImageWMS ? source.getUrl() : source.getUrls()[0],
         customParams: customParams,

--- a/src/serializer/MapFishPrintV3GeoJsonSerializer.js
+++ b/src/serializer/MapFishPrintV3GeoJsonSerializer.js
@@ -148,7 +148,6 @@ export class MapFishPrintV3GeoJsonSerializer extends BaseSerializer {
     });
 
     const serialized = {
-      ...super.serialize(layer, opts, viewResolution),
       ...{
         geoJson: {
           type: 'FeatureCollection',

--- a/src/serializer/MapFishPrintV3OSMSerializer.js
+++ b/src/serializer/MapFishPrintV3OSMSerializer.js
@@ -64,7 +64,6 @@ export class MapFishPrintV3OSMSerializer extends BaseSerializer {
     }
 
     const serialized = {
-      ...super.serialize(layer, opts),
       ...{
         name: layer.get('name'),
         opacity: layer.getOpacity(),

--- a/src/serializer/MapFishPrintV3WMSSerializer.js
+++ b/src/serializer/MapFishPrintV3WMSSerializer.js
@@ -79,7 +79,6 @@ export class MapFishPrintV3WMSSerializer extends BaseSerializer {
     } = source.getParams();
 
     const serialized = {
-      ...super.serialize(layer, opts),
       ...{
         baseURL: source instanceof OlSourceImageWMS ? source.getUrl() : source.getUrls()[0],
         customParams,

--- a/src/serializer/MapFishPrintV3WMTSSerializer.js
+++ b/src/serializer/MapFishPrintV3WMTSSerializer.js
@@ -53,7 +53,6 @@ export class MapFishPrintV3WMTSSerializer extends BaseSerializer {
     // 28mm is the pixel size
     const scaleDenominators = tileGrid.getResolutions().map(resolution => resolution / 0.00028);
     const serialized = {
-      ...super.serialize(layer, opts),
       ...opts,
       baseURL: source.getUrls()[0],
       customParams: undefined,


### PR DESCRIPTION
This suggests to remove the unsupported layer attributes min- and maxScaleDenominator. As the base serialize method is thereby not needed anymore, it has been removed as well.

Please review @terrestris/devs.