### PR TITLE
Fix serializing WMTS layers

### DIFF
--- a/src/serializer/MapFishPrintV3WMTSSerializer.js
+++ b/src/serializer/MapFishPrintV3WMTSSerializer.js
@@ -75,7 +75,7 @@ export class MapFishPrintV3WMTSSerializer extends BaseSerializer {
         matrixSize: [Math.pow(2, index), Math.pow(2, index)],
         scaleDenominator: scaleDenominators[index],
         tileSize: [tileGrid.getTileSize(index), tileGrid.getTileSize(index)],
-        topLeftCorner: tileGrid.getOrigin()
+        topLeftCorner: tileGrid.getOrigin(index) || tileGrid.getOrigin()
       })),
       matrixSet: source.getMatrixSet(),
       mergeableParams: undefined,

--- a/src/serializer/MapFishPrintV3WMTSSerializer.js
+++ b/src/serializer/MapFishPrintV3WMTSSerializer.js
@@ -49,6 +49,14 @@ export class MapFishPrintV3WMTSSerializer extends BaseSerializer {
       return;
     }
 
+    let baseUrl = source.getUrls()[0];
+
+    // MapFish Print replaces {style}
+    // https://mapfish.github.io/mapfish-print-doc/layers.html#WMTS%20Layer
+    if (baseUrl.indexOf('{Style}') > -1) {
+      baseUrl = baseUrl.replace('{Style}', '{style}');
+    }
+
     const tileGrid = source.getTileGrid();
     // 28mm is the pixel size
     const scaleDenominators = tileGrid.getResolutions().map(resolution => resolution / 0.00028);


### PR DESCRIPTION
This fixes serialization of WMTS layers by:
* Setting the style path variable according the mapfish print spec (lowercase).
* Reading out the tile grid origin for the given resolution, if any.

Please review @terrestris/devs.