### PR TITLE
Fix style serialization

### DIFF
--- a/src/serializer/MapFishPrintV3GeoJsonSerializer.js
+++ b/src/serializer/MapFishPrintV3GeoJsonSerializer.js
@@ -249,7 +249,10 @@ export class MapFishPrintV3GeoJsonSerializer extends BaseSerializer {
         fontWeight: parsedFont.weight,
         fontStyle: parsedFont.style,
         fontColor: parseColor(get(textStyle, 'fill.color')).hex,
-        fontOpacity: get(parseColor(get(textStyle, 'fill.color')), 'rgba[3]')
+        fontOpacity: get(parseColor(get(textStyle, 'fill.color')), 'rgba[3]'),
+        strokeOpacity: 0,
+        fillOpacity: 0,
+        graphicOpacity: 0
       }};
     }
 

--- a/src/serializer/MapFishPrintV3GeoJsonSerializer.js
+++ b/src/serializer/MapFishPrintV3GeoJsonSerializer.js
@@ -142,7 +142,7 @@ export class MapFishPrintV3GeoJsonSerializer extends BaseSerializer {
           if (!serializedFeature.properties) {
             serializedFeature.properties = {};
           }
-          // serializedFeature.properties[this.constructor.FEAT_STYLE_PROPERTY] = styleName;
+          serializedFeature.properties[this.constructor.FEAT_STYLE_PROPERTY] = styleName;
         });
       }
     });
@@ -156,9 +156,7 @@ export class MapFishPrintV3GeoJsonSerializer extends BaseSerializer {
         },
         name: layer.get('name') || 'Vector Layer',
         opacity: layer.getOpacity(),
-        // TODO Currently not supported, GeoStyler MapFish JSON StyleParser should
-        // be used here!
-        style: {},
+        style: serializedStyles,
         type: this.constructor.TYPE_GEOJSON
       },
       ...opts


### PR DESCRIPTION
This fixes the serialization of the GeoJSON styles by:

* Readding the styles to the print payload.
* Hiding the geometries from the text style.

Please review @terrestris/devs.