### PR TITLE
fixed issue with illegal lineDash value being given to mapfish print.…

### DIFF
--- a/src/serializer/MapFishPrintV2VectorSerializer.js
+++ b/src/serializer/MapFishPrintV2VectorSerializer.js
@@ -231,7 +231,8 @@ export class MapFishPrintV2VectorSerializer extends BaseSerializer {
     if (textStyle && textStyle.text) {
       const parsedFont = parseFont(textStyle.font);
       style = {
-        ...style, ...{
+        ...style,
+        ...{
           label: textStyle.text,
           fontFamily: parsedFont.family.join(','),
           fontSize: parsedFont.size,

--- a/src/serializer/MapFishPrintV2VectorSerializer.js
+++ b/src/serializer/MapFishPrintV2VectorSerializer.js
@@ -230,15 +230,17 @@ export class MapFishPrintV2VectorSerializer extends BaseSerializer {
 
     if (textStyle && textStyle.text) {
       const parsedFont = parseFont(textStyle.font);
-      style = {...style, ...{
-        label: textStyle.text,
-        fontFamily: parsedFont.family.join(','),
-        fontSize: parsedFont.size,
-        fontWeight: parsedFont.weight,
-        fontStyle: parsedFont.style,
-        fontColor: parseColor(get(textStyle, 'fill.color')).hex,
-        fontOpacity: get(parseColor(get(textStyle, 'fill.color')), 'rgba[3]')
-      }};
+      style = {
+        ...style, ...{
+          label: textStyle.text,
+          fontFamily: parsedFont.family.join(','),
+          fontSize: parsedFont.size,
+          fontWeight: parsedFont.weight,
+          fontStyle: parsedFont.style,
+          fontColor: parseColor(get(textStyle, 'fill.color')).hex,
+          fontOpacity: get(parseColor(get(textStyle, 'fill.color')), 'rgba[3]')
+        }
+      };
     }
 
     return pickBy(style, v => v !== undefined);
@@ -387,7 +389,7 @@ export class MapFishPrintV2VectorSerializer extends BaseSerializer {
       lineJoin: olStrokeStyle.getLineJoin(),
       // If not set, getLineDash will return null.
       lineDash: olStrokeStyle.getLineDash() || undefined,
-      lineDashOffeset: olStrokeStyle.getLineDashOffset(),
+      lineDashOffset: olStrokeStyle.getLineDashOffset(),
       miterLimit: olStrokeStyle.getMiterLimit(),
       width: olStrokeStyle.getWidth()
     };

--- a/src/serializer/MapFishPrintV3GeoJsonSerializer.js
+++ b/src/serializer/MapFishPrintV3GeoJsonSerializer.js
@@ -178,7 +178,7 @@ export class MapFishPrintV3GeoJsonSerializer extends BaseSerializer {
 
     const fillStyle = this.writeFillStyle(olStyle.getFill());
     const imageStyle = this.writeImageStyle(olStyle.getImage());
-    const strokeStyle = this.writeStrokeStyle(olStyle.getStroke());
+    const strokeStyle = this.writeStrokeStyle(olStyle.getStroke())
     const textStyle = this.writeTextStyle(olStyle.getText());
 
     let style = {};
@@ -241,18 +241,20 @@ export class MapFishPrintV3GeoJsonSerializer extends BaseSerializer {
 
     if (textStyle && textStyle.text) {
       const parsedFont = parseFont(textStyle.font);
-      style = {...style, ...{
-        label: textStyle.text,
-        fontFamily: parsedFont.family.join(','),
-        fontSize: parsedFont.size,
-        fontWeight: parsedFont.weight,
-        fontStyle: parsedFont.style,
-        fontColor: parseColor(get(textStyle, 'fill.color')).hex,
-        fontOpacity: get(parseColor(get(textStyle, 'fill.color')), 'rgba[3]'),
-        strokeOpacity: 0,
-        fillOpacity: 0,
-        graphicOpacity: 0
-      }};
+      style = {
+        ...style, ...{
+          label: textStyle.text,
+          fontFamily: parsedFont.family.join(','),
+          fontSize: parsedFont.size,
+          fontWeight: parsedFont.weight,
+          fontStyle: parsedFont.style,
+          fontColor: parseColor(get(textStyle, 'fill.color')).hex,
+          fontOpacity: get(parseColor(get(textStyle, 'fill.color')), 'rgba[3]'),
+          strokeOpacity: 0,
+          fillOpacity: 0,
+          graphicOpacity: 0
+        }
+      };
     }
 
     return pickBy(style, v => v !== undefined);
@@ -351,7 +353,6 @@ export class MapFishPrintV3GeoJsonSerializer extends BaseSerializer {
     if (!(olRegularShape instanceof OlStyleRegularShape)) {
       return {};
     }
-
     return {
       angle: olRegularShape.getAngle(),
       fill: this.writeFillStyle(olRegularShape.getFill()),
@@ -374,12 +375,15 @@ export class MapFishPrintV3GeoJsonSerializer extends BaseSerializer {
    *                  instance.
    */
   writeFillStyle = olFillStyle => {
-    if (!(olFillStyle instanceof OlStyleFill)) {
+
+    if (olFillStyle && !(olFillStyle instanceof OlStyleFill)) {
       return {};
     }
 
     return {
-      color: olFillStyle.getColor()
+      // if no fill is given set it to full transparent. In some elemnts with stroke and no fill, the object cannot
+      // be rendered for some reason
+      color: olFillStyle ? olFillStyle.getColor() : 'rgb(0,0,0,0)'
     };
   }
 
@@ -395,13 +399,27 @@ export class MapFishPrintV3GeoJsonSerializer extends BaseSerializer {
       return {};
     }
 
+    // If not set, getLineDash will return null.
+    // according to http://mapfish.github.io/mapfish-print-doc/styles.html#mapfishJsonParser
+    // strokeDashstyle - (line, point, polygon) A string describing how to draw the line or an array of floats
+    // describing the line lengths and space lengths:
+
+    // dot - translates to dash array: [0.1, 2 * strokeWidth]
+    // dash - translates to dash array: [2 * strokeWidth, 2 * strokeWidth]
+    // dashdot - translates to dash array: [3 * strokeWidth, 2 * strokeWidth, 0.1, 2 * strokeWidth]
+    // longdash - translates to dash array: [4 * strokeWidth, 2 * strokeWidth]
+    // longdashdot - translates to dash array: [5 * strokeWidth, 2 * strokeWidth, 0.1, 2 * strokeWidth]
+    // {string containing spaces to delimit array elements} - Example: [1 2 3 1 2]
+
+    // olStrokeStyle.getLineDash() will return a number array, wich is not valid for mapfish print.
+    // Here we translate the number array in lineDash to a valid value recognized by mapfish print like "5 5" instead
+    // of [5, 5]
     return {
       color: olStrokeStyle.getColor(),
       lineCap: olStrokeStyle.getLineCap(),
       lineJoin: olStrokeStyle.getLineJoin(),
-      // If not set, getLineDash will return null.
-      lineDash: olStrokeStyle.getLineDash() || undefined,
-      lineDashOffeset: olStrokeStyle.getLineDashOffset(),
+      lineDash: olStrokeStyle.getLineDash().toString().replace(/\,/g, ' ') || undefined,
+      lineDashOffset: olStrokeStyle.getLineDashOffset(),
       miterLimit: olStrokeStyle.getMiterLimit(),
       width: olStrokeStyle.getWidth()
     };

--- a/src/serializer/MapFishPrintV3GeoJsonSerializer.js
+++ b/src/serializer/MapFishPrintV3GeoJsonSerializer.js
@@ -419,7 +419,7 @@ export class MapFishPrintV3GeoJsonSerializer extends BaseSerializer {
       color: olStrokeStyle.getColor(),
       lineCap: olStrokeStyle.getLineCap(),
       lineJoin: olStrokeStyle.getLineJoin(),
-      lineDash: olStrokeStyle.getLineDash().toString().replace(/\,/g, ' ') || undefined,
+      lineDash: olStrokeStyle.getLineDash() ? olStrokeStyle.getLineDash().toString().replace(/\,/g, ' ') : undefined,
       lineDashOffset: olStrokeStyle.getLineDashOffset(),
       miterLimit: olStrokeStyle.getMiterLimit(),
       width: olStrokeStyle.getWidth()

--- a/src/serializer/MapFishPrintV3GeoJsonSerializer.js
+++ b/src/serializer/MapFishPrintV3GeoJsonSerializer.js
@@ -178,7 +178,7 @@ export class MapFishPrintV3GeoJsonSerializer extends BaseSerializer {
 
     const fillStyle = this.writeFillStyle(olStyle.getFill());
     const imageStyle = this.writeImageStyle(olStyle.getImage());
-    const strokeStyle = this.writeStrokeStyle(olStyle.getStroke())
+    const strokeStyle = this.writeStrokeStyle(olStyle.getStroke());
     const textStyle = this.writeTextStyle(olStyle.getText());
 
     let style = {};
@@ -242,7 +242,8 @@ export class MapFishPrintV3GeoJsonSerializer extends BaseSerializer {
     if (textStyle && textStyle.text) {
       const parsedFont = parseFont(textStyle.font);
       style = {
-        ...style, ...{
+        ...style,
+        ...{
           label: textStyle.text,
           fontFamily: parsedFont.family.join(','),
           fontSize: parsedFont.size,
@@ -353,6 +354,7 @@ export class MapFishPrintV3GeoJsonSerializer extends BaseSerializer {
     if (!(olRegularShape instanceof OlStyleRegularShape)) {
       return {};
     }
+
     return {
       angle: olRegularShape.getAngle(),
       fill: this.writeFillStyle(olRegularShape.getFill()),
@@ -375,7 +377,6 @@ export class MapFishPrintV3GeoJsonSerializer extends BaseSerializer {
    *                  instance.
    */
   writeFillStyle = olFillStyle => {
-
     if (olFillStyle && !(olFillStyle instanceof OlStyleFill)) {
       return {};
     }

--- a/src/serializer/MapFishPrintV3GeoJsonSerializer.js
+++ b/src/serializer/MapFishPrintV3GeoJsonSerializer.js
@@ -384,7 +384,7 @@ export class MapFishPrintV3GeoJsonSerializer extends BaseSerializer {
     return {
       // if no fill is given set it to full transparent. In some elemnts with stroke and no fill, the object cannot
       // be rendered for some reason
-      color: olFillStyle ? olFillStyle.getColor() : 'rgb(0,0,0,0)'
+      color: olFillStyle ? olFillStyle.getColor() : 'rgba(0,0,0,0)'
     };
   }
 


### PR DESCRIPTION
- Fixed issue with illegal `lineDash` value being given to mapfish print. `olStrokeStyle.getLineDash()` will return a number array, which is not valid for mapfish-print. Replaced by a valid value. See more details [here](http://mapfish.github.io/mapfish-print-doc/styles.html#mapfishJsonParser)  

- Fixed typo. 

- Added fallback in case fill is not given to a polygon. For some reason if a bolygon contour is dashed and no fill is given, nothing will be rendered. Added a full transparent fill as a fallback.

Please review @terrestris/devs 