### PR TITLE
Determine the graphicName of a RegularShape

### DIFF
--- a/dist/interaction/InteractionTransform.js
+++ b/dist/interaction/InteractionTransform.js
@@ -5,53 +5,49 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.OlInteractionTransform = undefined;
 
-var _collection = require('ol/collection');
+var _Collection = require('ol/Collection');
 
-var _collection2 = _interopRequireDefault(_collection);
+var _Collection2 = _interopRequireDefault(_Collection);
 
-var _vector = require('ol/layer/vector');
+var _Vector = require('ol/layer/Vector');
 
-var _vector2 = _interopRequireDefault(_vector);
+var _Vector2 = _interopRequireDefault(_Vector);
 
-var _vector3 = require('ol/source/vector');
+var _Vector3 = require('ol/source/Vector');
 
-var _vector4 = _interopRequireDefault(_vector3);
+var _Vector4 = _interopRequireDefault(_Vector3);
 
-var _pointer = require('ol/interaction/pointer');
+var _Pointer = require('ol/interaction/Pointer');
 
-var _pointer2 = _interopRequireDefault(_pointer);
+var _Pointer2 = _interopRequireDefault(_Pointer);
 
-var _style = require('ol/style/style');
+var _Style = require('ol/style/Style');
 
-var _style2 = _interopRequireDefault(_style);
+var _Style2 = _interopRequireDefault(_Style);
 
-var _stroke = require('ol/style/stroke');
+var _Stroke = require('ol/style/Stroke');
 
-var _stroke2 = _interopRequireDefault(_stroke);
+var _Stroke2 = _interopRequireDefault(_Stroke);
 
-var _fill = require('ol/style/fill');
+var _Fill = require('ol/style/Fill');
 
-var _fill2 = _interopRequireDefault(_fill);
+var _Fill2 = _interopRequireDefault(_Fill);
 
-var _regularshape = require('ol/style/regularshape');
+var _RegularShape = require('ol/style/RegularShape');
 
-var _regularshape2 = _interopRequireDefault(_regularshape);
+var _RegularShape2 = _interopRequireDefault(_RegularShape);
 
-var _feature = require('ol/feature');
+var _Feature = require('ol/Feature');
 
-var _feature2 = _interopRequireDefault(_feature);
+var _Feature2 = _interopRequireDefault(_Feature);
 
-var _point = require('ol/geom/point');
+var _Point = require('ol/geom/Point');
 
-var _point2 = _interopRequireDefault(_point);
+var _Point2 = _interopRequireDefault(_Point);
 
-var _polygon = require('ol/geom/polygon');
-
-var _polygon2 = _interopRequireDefault(_polygon);
+var _Polygon = require('ol/geom/Polygon');
 
 var _extent = require('ol/extent');
-
-var _extent2 = _interopRequireDefault(_extent);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -120,7 +116,7 @@ var OlInteractionTransform = exports.OlInteractionTransform = function (_OlInter
         this.getMap().removeLayer(this.overlayLayer_);
       }
 
-      _pointer2.default.prototype.setMap.call(this, map);
+      _Pointer2.default.prototype.setMap.call(this, map);
       this.overlayLayer_.setMap(map);
 
       if (map !== null) {
@@ -132,27 +128,27 @@ var OlInteractionTransform = exports.OlInteractionTransform = function (_OlInter
     _this.setActive = function (b) {
       this.select(null);
       this.overlayLayer_.setVisible(b);
-      _pointer2.default.prototype.setActive.call(this, b);
+      _Pointer2.default.prototype.setActive.call(this, b);
     };
 
     _this.setDefaultStyle = function () {
       // Style
-      var stroke = new _stroke2.default({
+      var stroke = new _Stroke2.default({
         color: 'rgba(255, 0, 0, 1)',
         width: 1
       });
-      var strokedash = new _stroke2.default({
+      var strokedash = new _Stroke2.default({
         color: 'rgba(255, 0, 0, 1)',
         width: 1,
         lineDash: [4, 4]
       });
-      var fill0 = new _fill2.default({
+      var fill0 = new _Fill2.default({
         color: 'rgba(255, 0, 0, 0.01)'
       });
-      var fill = new _fill2.default({
+      var fill = new _Fill2.default({
         color: 'rgba(255, 255, 255, 0.8)'
       });
-      var circle = new _regularshape2.default({
+      var circle = new _RegularShape2.default({
         fill: fill,
         stroke: stroke,
         radius: this.isTouch ? 12 : 6,
@@ -161,7 +157,7 @@ var OlInteractionTransform = exports.OlInteractionTransform = function (_OlInter
 
       circle.getAnchor()[0] = this.isTouch ? -10 : -5;
 
-      var bigpt = new _regularshape2.default({
+      var bigpt = new _RegularShape2.default({
         fill: fill,
         stroke: stroke,
         radius: this.isTouch ? 16 : 8,
@@ -169,7 +165,7 @@ var OlInteractionTransform = exports.OlInteractionTransform = function (_OlInter
         angle: Math.PI / 4
       });
 
-      var smallpt = new _regularshape2.default({
+      var smallpt = new _RegularShape2.default({
         fill: fill,
         stroke: stroke,
         radius: this.isTouch ? 12 : 6,
@@ -186,7 +182,7 @@ var OlInteractionTransform = exports.OlInteractionTransform = function (_OlInter
        * @return {[type]}           [description]
        */
       function createStyle(img, stroke, fill) {
-        return [new _style2.default({
+        return [new _Style2.default({
           image: img,
           stroke: stroke,
           fill: fill
@@ -311,23 +307,23 @@ var OlInteractionTransform = exports.OlInteractionTransform = function (_OlInter
 
       if (center === true) {
         if (!this.ispt_) {
-          this.overlayLayer_.getSource().addFeature(new _feature2.default({
-            geometry: new _point2.default(this.center_),
+          this.overlayLayer_.getSource().addFeature(new _Feature2.default({
+            geometry: new _Point2.default(this.center_),
             handle: 'rotate0'
           }));
           ext = this.feature_.getGeometry().getExtent();
-          geom = _polygon2.default.fromExtent(ext);
-          f = this.bbox_ = new _feature2.default(geom);
+          geom = (0, _Polygon.fromExtent)(ext);
+          f = this.bbox_ = new _Feature2.default(geom);
           this.overlayLayer_.getSource().addFeature(f);
         }
       } else {
         ext = this.feature_.getGeometry().getExtent();
         if (this.ispt_) {
           var p = this.getMap().getPixelFromCoordinate([ext[0], ext[1]]);
-          ext = _extent2.default.boundingExtent([this.getMap().getCoordinateFromPixel([p[0] - 10, p[1] - 10]), this.getMap().getCoordinateFromPixel([p[0] + 10, p[1] + 10])]);
+          ext = (0, _extent.boundingExtent)([this.getMap().getCoordinateFromPixel([p[0] - 10, p[1] - 10]), this.getMap().getCoordinateFromPixel([p[0] + 10, p[1] + 10])]);
         }
-        geom = _polygon2.default.fromExtent(ext);
-        f = this.bbox_ = new _feature2.default(geom);
+        geom = (0, _Polygon.fromExtent)(ext);
+        f = this.bbox_ = new _Feature2.default(geom);
         var features = [];
         var g = geom.getCoordinates()[0];
 
@@ -336,8 +332,8 @@ var OlInteractionTransform = exports.OlInteractionTransform = function (_OlInter
 
           // Middle
           if (this.get('stretch') && this.get('scale')) for (var i = 0; i < g.length - 1; i++) {
-            f = new _feature2.default({
-              geometry: new _point2.default([(g[i][0] + g[i + 1][0]) / 2, (g[i][1] + g[i + 1][1]) / 2]),
+            f = new _Feature2.default({
+              geometry: new _Point2.default([(g[i][0] + g[i + 1][0]) / 2, (g[i][1] + g[i + 1][1]) / 2]),
               handle: 'scale',
               constraint: i % 2 ? 'h' : 'v',
               option: i
@@ -347,8 +343,8 @@ var OlInteractionTransform = exports.OlInteractionTransform = function (_OlInter
 
           // Handles
           if (this.get('scale')) for (var j = 0; j < g.length - 1; j++) {
-            f = new _feature2.default({
-              geometry: new _point2.default(g[j]),
+            f = new _Feature2.default({
+              geometry: new _Point2.default(g[j]),
               handle: 'scale',
               option: j
             });
@@ -357,8 +353,8 @@ var OlInteractionTransform = exports.OlInteractionTransform = function (_OlInter
 
           // Center
           if (this.get('translate') && !this.get('translateFeature')) {
-            f = new _feature2.default({
-              geometry: new _point2.default([(g[0][0] + g[2][0]) / 2, (g[0][1] + g[2][1]) / 2]),
+            f = new _Feature2.default({
+              geometry: new _Point2.default([(g[0][0] + g[2][0]) / 2, (g[0][1] + g[2][1]) / 2]),
               handle: 'translate'
             });
             features.push(f);
@@ -367,8 +363,8 @@ var OlInteractionTransform = exports.OlInteractionTransform = function (_OlInter
 
         // Rotate
         if (this.get('rotate')) {
-          f = new _feature2.default({
-            geometry: new _point2.default(g[3]),
+          f = new _Feature2.default({
+            geometry: new _Point2.default(g[3]),
             handle: 'rotate'
           });
           features.push(f);
@@ -405,8 +401,8 @@ var OlInteractionTransform = exports.OlInteractionTransform = function (_OlInter
         this.coordinate_ = evt.coordinate;
         this.pixel_ = evt.pixel;
         this.geom_ = this.feature_.getGeometry().clone();
-        this.extent_ = _polygon2.default.fromExtent(this.geom_.getExtent()).getCoordinates()[0];
-        this.center_ = _extent2.default.getCenter(this.geom_.getExtent());
+        this.extent_ = (0, _Polygon.fromExtent)(this.geom_.getExtent()).getCoordinates()[0];
+        this.center_ = (0, _extent.getCenter)(this.geom_.getExtent());
         this.angle_ = Math.atan2(this.center_[1] - evt.coordinate[1], this.center_[0] - evt.coordinate[0]);
 
         this.dispatchEvent({
@@ -561,9 +557,9 @@ var OlInteractionTransform = exports.OlInteractionTransform = function (_OlInter
       return false;
     };
 
-    _this.handles_ = new _collection2.default();
-    _this.overlayLayer_ = new _vector2.default({
-      source: new _vector4.default({
+    _this.handles_ = new _Collection2.default();
+    _this.overlayLayer_ = new _Vector2.default({
+      source: new _Vector4.default({
         features: _this.handles_,
         useSpatialIndex: false
       }),
@@ -697,6 +693,6 @@ var OlInteractionTransform = exports.OlInteractionTransform = function (_OlInter
 
 
   return OlInteractionTransform;
-}(_pointer2.default);
+}(_Pointer2.default);
 
 exports.default = OlInteractionTransform;

--- a/dist/manager/BaseMapFishPrintManager.js
+++ b/dist/manager/BaseMapFishPrintManager.js
@@ -7,37 +7,33 @@ exports.BaseMapFishPrintManager = undefined;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var _map = require('ol/map');
+var _Map = require('ol/Map');
 
-var _map2 = _interopRequireDefault(_map);
+var _Map2 = _interopRequireDefault(_Map);
 
-var _vector = require('ol/layer/vector');
+var _Vector = require('ol/layer/Vector');
 
-var _vector2 = _interopRequireDefault(_vector);
+var _Vector2 = _interopRequireDefault(_Vector);
 
-var _vector3 = require('ol/source/vector');
+var _Vector3 = require('ol/source/Vector');
 
-var _vector4 = _interopRequireDefault(_vector3);
+var _Vector4 = _interopRequireDefault(_Vector3);
 
-var _feature = require('ol/feature');
+var _Feature = require('ol/Feature');
 
-var _feature2 = _interopRequireDefault(_feature);
+var _Feature2 = _interopRequireDefault(_Feature);
 
-var _polygon = require('ol/geom/polygon');
-
-var _polygon2 = _interopRequireDefault(_polygon);
+var _Polygon = require('ol/geom/Polygon');
 
 var _extent = require('ol/extent');
 
-var _extent2 = _interopRequireDefault(_extent);
+var _Style = require('ol/style/Style');
 
-var _style = require('ol/style/style');
+var _Style2 = _interopRequireDefault(_Style);
 
-var _style2 = _interopRequireDefault(_style);
+var _Fill = require('ol/style/Fill');
 
-var _fill = require('ol/style/fill');
-
-var _fill2 = _interopRequireDefault(_fill);
+var _Fill2 = _interopRequireDefault(_Fill);
 
 var _InteractionTransform = require('../interaction/InteractionTransform');
 
@@ -254,12 +250,12 @@ var BaseMapFishPrintManager = exports.BaseMapFishPrintManager = function (_Obser
     };
 
     _this.initPrintExtentLayer = function () {
-      if (!(_this.extentLayer instanceof _vector2.default)) {
-        var extentLayer = new _vector2.default({
+      if (!(_this.extentLayer instanceof _Vector2.default)) {
+        var extentLayer = new _Vector2.default({
           name: _this.constructor.EXTENT_LAYER_NAME,
-          source: new _vector4.default(),
-          style: new _style2.default({
-            fill: new _fill2.default({
+          source: new _Vector4.default(),
+          style: new _Style2.default({
+            fill: new _Fill2.default({
               color: 'rgba(255, 255, 130, 0)'
             })
           })
@@ -317,7 +313,7 @@ var BaseMapFishPrintManager = exports.BaseMapFishPrintManager = function (_Obser
 
     _this.initPrintExtentFeature = function () {
       var printExtent = _this.calculatePrintExtent();
-      var extentFeature = new _feature2.default(_polygon2.default.fromExtent(printExtent));
+      var extentFeature = new _Feature2.default((0, _Polygon.fromExtent)(printExtent));
       var extentLayerSource = _this.extentLayer.getSource();
 
       _this._extentFeature = extentFeature;
@@ -356,13 +352,13 @@ var BaseMapFishPrintManager = exports.BaseMapFishPrintManager = function (_Obser
     _this.getClosestScaleToFitExtentFeature = function () {
       var scales = _this.getScales();
       var printFeatureExtent = _this._extentFeature.getGeometry().getExtent();
-      var printFeatureSize = _extent2.default.getSize(printFeatureExtent);
+      var printFeatureSize = (0, _extent.getSize)(printFeatureExtent);
       var closest = Number.POSITIVE_INFINITY;
       var fitScale = scales[0];
 
       scales.forEach(function (scale) {
         var printScaleExtent = _this.calculatePrintExtent(scale.value);
-        var printScaleSize = _extent2.default.getSize(printScaleExtent);
+        var printScaleSize = (0, _extent.getSize)(printScaleExtent);
         var diff = Math.abs(printScaleSize[0] - printFeatureSize[0]) + Math.abs(printScaleSize[1] - printFeatureSize[1]);
 
         if (diff < closest) {
@@ -382,7 +378,7 @@ var BaseMapFishPrintManager = exports.BaseMapFishPrintManager = function (_Obser
 
       scales.forEach(function (scale) {
         var printExtent = _this.calculatePrintExtent(scale.value);
-        var contains = _extent2.default.containsExtent(mapExtent, printExtent);
+        var contains = (0, _extent.containsExtent)(mapExtent, printExtent);
 
         if (contains) {
           fitScale = scale;
@@ -407,7 +403,7 @@ var BaseMapFishPrintManager = exports.BaseMapFishPrintManager = function (_Obser
     };
 
     _this.setRotation = function (rotation) {
-      var center = _extent2.default.getCenter(_this._extentFeature.getGeometry().getExtent());
+      var center = (0, _extent.getCenter)(_this._extentFeature.getGeometry().getExtent());
       _this._extentFeature.getGeometry().rotate(rotation, center);
     };
 
@@ -415,7 +411,7 @@ var BaseMapFishPrintManager = exports.BaseMapFishPrintManager = function (_Obser
       if (_this.isInitiated()) {
         var printExtent = _this.calculatePrintExtent();
         if (_this._extentFeature) {
-          _this._extentFeature.setGeometry(_polygon2.default.fromExtent(printExtent));
+          _this._extentFeature.setGeometry((0, _Polygon.fromExtent)(printExtent));
         }
       }
     };
@@ -434,7 +430,7 @@ var BaseMapFishPrintManager = exports.BaseMapFishPrintManager = function (_Obser
 
       var center = void 0;
       if (_this._extentFeature) {
-        center = _extent2.default.getCenter(_this._extentFeature.getGeometry().getExtent());
+        center = (0, _extent.getCenter)(_this._extentFeature.getGeometry().getExtent());
       } else {
         center = _this.map.getView().getCenter();
       }
@@ -554,7 +550,7 @@ var BaseMapFishPrintManager = exports.BaseMapFishPrintManager = function (_Obser
 
     Object.assign.apply(Object, [_this].concat(_toConsumableArray(opts)));
 
-    if (!(_this.map instanceof _map2.default)) {
+    if (!(_this.map instanceof _Map2.default)) {
       _Logger2.default.warn('Invalid value given to config option `map`. You need to ' + 'provide an ol.Map to use the PrintManager.');
     }
 

--- a/dist/manager/MapFishPrintV2Manager.js
+++ b/dist/manager/MapFishPrintV2Manager.js
@@ -9,15 +9,13 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
 
 var _extent = require('ol/extent');
 
-var _extent2 = _interopRequireDefault(_extent);
+var _TileWMS = require('ol/source/TileWMS');
 
-var _tilewms = require('ol/source/tilewms');
+var _TileWMS2 = _interopRequireDefault(_TileWMS);
 
-var _tilewms2 = _interopRequireDefault(_tilewms);
+var _ImageWMS = require('ol/source/ImageWMS');
 
-var _imagewms = require('ol/source/imagewms');
-
-var _imagewms2 = _interopRequireDefault(_imagewms);
+var _ImageWMS2 = _interopRequireDefault(_ImageWMS);
 
 var _BaseMapFishPrintManager = require('./BaseMapFishPrintManager');
 
@@ -172,7 +170,7 @@ var MapFishPrintV2Manager = exports.MapFishPrintV2Manager = function (_BaseMapFi
         dpi: _this.getDpi().value,
         layers: serializedLayers,
         pages: [{
-          center: _extent2.default.getCenter(extentFeatureGeometry.getExtent()),
+          center: (0, _extent.getCenter)(extentFeatureGeometry.getExtent()),
           scale: _this.getScale().value,
           rotation: _this.calculateRotation() || 0
         }],
@@ -209,7 +207,7 @@ var MapFishPrintV2Manager = exports.MapFishPrintV2Manager = function (_BaseMapFi
     };
 
     _this.serializeLegend = function (layer) {
-      if (layer.getSource() instanceof _tilewms2.default || layer.getSource() instanceof _imagewms2.default) {
+      if (layer.getSource() instanceof _TileWMS2.default || layer.getSource() instanceof _ImageWMS2.default) {
         return {
           name: layer.get('name') || '',
           classes: [{

--- a/dist/serializer/VectorSerializer.js
+++ b/dist/serializer/VectorSerializer.js
@@ -11,53 +11,51 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
 
-var _vector = require('ol/source/vector');
+var _Vector = require('ol/source/Vector');
 
-var _vector2 = _interopRequireDefault(_vector);
+var _Vector2 = _interopRequireDefault(_Vector);
 
-var _geojson = require('ol/format/geojson');
+var _GeoJSON = require('ol/format/GeoJSON');
 
-var _geojson2 = _interopRequireDefault(_geojson);
+var _GeoJSON2 = _interopRequireDefault(_GeoJSON);
 
-var _style = require('ol/style/style');
+var _Style = require('ol/style/Style');
 
-var _style2 = _interopRequireDefault(_style);
+var _Style2 = _interopRequireDefault(_Style);
 
-var _regularshape = require('ol/style/regularshape');
+var _RegularShape = require('ol/style/RegularShape');
 
-var _regularshape2 = _interopRequireDefault(_regularshape);
+var _RegularShape2 = _interopRequireDefault(_RegularShape);
 
-var _polygon = require('ol/geom/polygon');
+var _Polygon = require('ol/geom/Polygon');
 
-var _polygon2 = _interopRequireDefault(_polygon);
+var _Feature = require('ol/Feature');
 
-var _feature = require('ol/feature');
+var _Feature2 = _interopRequireDefault(_Feature);
 
-var _feature2 = _interopRequireDefault(_feature);
+var _Icon = require('ol/style/Icon');
 
-var _icon = require('ol/style/icon');
+var _Icon2 = _interopRequireDefault(_Icon);
 
-var _icon2 = _interopRequireDefault(_icon);
+var _Circle = require('ol/style/Circle');
 
-var _circle = require('ol/style/circle');
+var _Circle2 = _interopRequireDefault(_Circle);
 
-var _circle2 = _interopRequireDefault(_circle);
+var _Image = require('ol/style/Image');
 
-var _image = require('ol/style/image');
+var _Image2 = _interopRequireDefault(_Image);
 
-var _image2 = _interopRequireDefault(_image);
+var _Text = require('ol/style/Text');
 
-var _text = require('ol/style/text');
+var _Text2 = _interopRequireDefault(_Text);
 
-var _text2 = _interopRequireDefault(_text);
+var _Stroke = require('ol/style/Stroke');
 
-var _stroke = require('ol/style/stroke');
+var _Stroke2 = _interopRequireDefault(_Stroke);
 
-var _stroke2 = _interopRequireDefault(_stroke);
+var _Fill = require('ol/style/Fill');
 
-var _fill = require('ol/style/fill');
-
-var _fill2 = _interopRequireDefault(_fill);
+var _Fill2 = _interopRequireDefault(_Fill);
 
 var _get2 = require('lodash/get');
 
@@ -118,7 +116,7 @@ var VectorSerializer = exports.VectorSerializer = function (_BaseSerializer) {
     var _this = _possibleConstructorReturn(this, (VectorSerializer.__proto__ || Object.getPrototypeOf(VectorSerializer)).call(this, arguments));
 
     _this.writeStyle = function (olStyle, geomType) {
-      if (!(olStyle instanceof _style2.default)) {
+      if (!(olStyle instanceof _Style2.default)) {
         return undefined;
       }
 
@@ -143,15 +141,13 @@ var VectorSerializer = exports.VectorSerializer = function (_BaseSerializer) {
             externalGraphic: imageStyle.src,
             graphicWidth: (0, _get3.default)(imageStyle, 'size[0]'),
             graphicHeight: (0, _get3.default)(imageStyle, 'size[1]'),
-            graphicOpacity: imageStyle instanceof _icon2.default ? imageStyle.opacity : undefined,
+            graphicOpacity: imageStyle instanceof _Icon2.default ? imageStyle.opacity : undefined,
             // TODO not available in ol3?
             graphicXOffset: undefined,
             // TODO not available in ol3?
             graphicYOffset: undefined,
             rotation: imageStyle.rotation,
-            // TODO Support full list of graphics: 'circle', 'square', 'star', 'x',
-            // 'cross' and 'triangle'
-            graphicName: 'circle'
+            graphicName: (0, _get3.default)(imageStyle, 'graphicName') || 'circle'
           };
           break;
         case 'LineString':
@@ -201,25 +197,25 @@ var VectorSerializer = exports.VectorSerializer = function (_BaseSerializer) {
     };
 
     _this.writeImageStyle = function (olImageStyle) {
-      if (!(olImageStyle instanceof _image2.default)) {
+      if (!(olImageStyle instanceof _Image2.default)) {
         return {};
       }
 
-      if (olImageStyle instanceof _circle2.default) {
+      if (olImageStyle instanceof _Circle2.default) {
         return _this.writeCircleStyle(olImageStyle);
       }
 
-      if (olImageStyle instanceof _icon2.default) {
+      if (olImageStyle instanceof _Icon2.default) {
         return _this.writeIconStyle(olImageStyle);
       }
 
-      if (olImageStyle instanceof _regularshape2.default) {
+      if (olImageStyle instanceof _RegularShape2.default) {
         return _this.writeRegularShapeStyle(olImageStyle);
       }
     };
 
     _this.writeCircleStyle = function (olCircleStyle) {
-      if (!(olCircleStyle instanceof _circle2.default)) {
+      if (!(olCircleStyle instanceof _Circle2.default)) {
         return {};
       }
 
@@ -237,7 +233,7 @@ var VectorSerializer = exports.VectorSerializer = function (_BaseSerializer) {
     };
 
     _this.writeIconStyle = function (olIconStyle) {
-      if (!(olIconStyle instanceof _icon2.default)) {
+      if (!(olIconStyle instanceof _Icon2.default)) {
         return {};
       }
 
@@ -259,9 +255,32 @@ var VectorSerializer = exports.VectorSerializer = function (_BaseSerializer) {
     };
 
     _this.writeRegularShapeStyle = function (olRegularShape) {
-      if (!(olRegularShape instanceof _regularshape2.default)) {
+      if (!(olRegularShape instanceof _RegularShape2.default)) {
         return {};
       }
+
+      /**
+       * Returns the graphicName of a RegularShape or undefined based on the
+       * number of points, radius and angle.
+       *
+       * @returns {String | undefined} The graphicName of a RegularShape feature
+       *                                (triangle, square, cross, x and star)
+       */
+      var getGraphicName = function getGraphicName() {
+        if (olRegularShape.getPoints() === 3) {
+          return 'triangle';
+        } else if (olRegularShape.getPoints() === 4 && olRegularShape.getRadius2() === undefined) {
+          return 'square';
+        } else if (olRegularShape.getPoints() === 4 && olRegularShape.getRadius2() !== undefined && olRegularShape.getAngle() === 0) {
+          return 'cross';
+        } else if (olRegularShape.getPoints() === 4 && olRegularShape.getAngle() !== 0) {
+          return 'x';
+        } else if (olRegularShape.getPoints() === 5) {
+          return 'star';
+        } else {
+          return undefined;
+        }
+      };
 
       return {
         angle: olRegularShape.getAngle(),
@@ -274,12 +293,13 @@ var VectorSerializer = exports.VectorSerializer = function (_BaseSerializer) {
         rotation: olRegularShape.getRotation(),
         scale: olRegularShape.getScale(),
         snapToPixel: olRegularShape.getSnapToPixel(),
-        stroke: _this.writeStrokeStyle(olRegularShape.getStroke())
+        stroke: _this.writeStrokeStyle(olRegularShape.getStroke()),
+        graphicName: getGraphicName()
       };
     };
 
     _this.writeFillStyle = function (olFillStyle) {
-      if (!(olFillStyle instanceof _fill2.default)) {
+      if (!(olFillStyle instanceof _Fill2.default)) {
         return {};
       }
 
@@ -289,7 +309,7 @@ var VectorSerializer = exports.VectorSerializer = function (_BaseSerializer) {
     };
 
     _this.writeStrokeStyle = function (olStrokeStyle) {
-      if (!(olStrokeStyle instanceof _stroke2.default)) {
+      if (!(olStrokeStyle instanceof _Stroke2.default)) {
         return {};
       }
 
@@ -306,7 +326,7 @@ var VectorSerializer = exports.VectorSerializer = function (_BaseSerializer) {
     };
 
     _this.writeTextStyle = function (olTextStyle) {
-      if (!(olTextStyle instanceof _text2.default)) {
+      if (!(olTextStyle instanceof _Text2.default)) {
         return {};
       }
 
@@ -362,7 +382,7 @@ var VectorSerializer = exports.VectorSerializer = function (_BaseSerializer) {
       }
 
       var features = source.getFeatures();
-      var format = new _geojson2.default();
+      var format = new _GeoJSON2.default();
       var serializedFeatures = [];
       var serializedStyles = {};
       var serializedStylesDict = {};
@@ -378,7 +398,7 @@ var VectorSerializer = exports.VectorSerializer = function (_BaseSerializer) {
         // transform circles to polygons.
         if (geometryType === _this2.constructor.CIRCLE_GEOMETRY_TYPE) {
           var style = feature.getStyle();
-          var polyFeature = new _feature2.default(_polygon2.default.fromCircle(geometry));
+          var polyFeature = new _Feature2.default((0, _Polygon.fromCircle)(geometry));
           polyFeature.setStyle(style);
           feature = polyFeature;
         }
@@ -397,7 +417,7 @@ var VectorSerializer = exports.VectorSerializer = function (_BaseSerializer) {
         }
 
         // assumption below: styles is an array of OlStyleStyle
-        if (styles instanceof _style2.default) {
+        if (styles instanceof _Style2.default) {
           styles = [styles];
         }
 
@@ -522,5 +542,5 @@ var VectorSerializer = exports.VectorSerializer = function (_BaseSerializer) {
 VectorSerializer.TYPE_VECTOR = 'Vector';
 VectorSerializer.CIRCLE_GEOMETRY_TYPE = 'Circle';
 VectorSerializer.FEAT_STYLE_PROPERTY = '_style';
-VectorSerializer.sourceCls = [_vector2.default];
+VectorSerializer.sourceCls = [_Vector2.default];
 exports.default = VectorSerializer;

--- a/dist/serializer/WMSSerializer.js
+++ b/dist/serializer/WMSSerializer.js
@@ -11,13 +11,13 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
 
-var _imagewms = require('ol/source/imagewms');
+var _ImageWMS = require('ol/source/ImageWMS');
 
-var _imagewms2 = _interopRequireDefault(_imagewms);
+var _ImageWMS2 = _interopRequireDefault(_ImageWMS);
 
-var _tilewms = require('ol/source/tilewms');
+var _TileWMS = require('ol/source/TileWMS');
 
-var _tilewms2 = _interopRequireDefault(_tilewms);
+var _TileWMS2 = _interopRequireDefault(_TileWMS);
 
 var _BaseSerializer2 = require('./BaseSerializer');
 
@@ -99,12 +99,12 @@ var WMSSerializer = exports.WMSSerializer = function (_BaseSerializer) {
           customParams = _objectWithoutProperties(_source$getParams, ['LAYERS', 'STYLES', 'VERSION', 'WIDTH', 'HEIGHT', 'FORMAT', 'BBOX', 'CRS', 'SRS']);
 
       var serialized = _extends({}, _get(WMSSerializer.prototype.__proto__ || Object.getPrototypeOf(WMSSerializer.prototype), 'serialize', this).call(this, layer, source), {
-        baseURL: source instanceof _imagewms2.default ? source.getUrl() : source.getUrls()[0],
+        baseURL: source instanceof _ImageWMS2.default ? source.getUrl() : source.getUrls()[0],
         customParams: customParams,
         format: source.getParams().FORMAT || 'image/png',
         layers: layersArray,
         opacity: layer.getOpacity(),
-        singleTile: source instanceof _imagewms2.default,
+        singleTile: source instanceof _ImageWMS2.default,
         styles: stylesArray,
         type: this.constructor.TYPE_WMS
       });
@@ -117,5 +117,5 @@ var WMSSerializer = exports.WMSSerializer = function (_BaseSerializer) {
 }(_BaseSerializer3.default);
 
 WMSSerializer.TYPE_WMS = 'WMS';
-WMSSerializer.sourceCls = [_imagewms2.default, _tilewms2.default];
+WMSSerializer.sourceCls = [_ImageWMS2.default, _TileWMS2.default];
 exports.default = WMSSerializer;

--- a/dist/util/Shared.js
+++ b/dist/util/Shared.js
@@ -7,21 +7,19 @@ exports.Shared = undefined;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var _group = require('ol/layer/group');
+var _Group = require('ol/layer/Group');
 
-var _group2 = _interopRequireDefault(_group);
+var _Group2 = _interopRequireDefault(_Group);
 
-var _tilewms = require('ol/source/tilewms');
+var _TileWMS = require('ol/source/TileWMS');
 
-var _tilewms2 = _interopRequireDefault(_tilewms);
+var _TileWMS2 = _interopRequireDefault(_TileWMS);
 
-var _imagewms = require('ol/source/imagewms');
+var _ImageWMS = require('ol/source/ImageWMS');
 
-var _imagewms2 = _interopRequireDefault(_imagewms);
+var _ImageWMS2 = _interopRequireDefault(_ImageWMS);
 
-var _proj = require('ol/proj');
-
-var _proj2 = _interopRequireDefault(_proj);
+var _Units = require('ol/proj/Units');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -57,7 +55,7 @@ Shared.getMapLayers = function (collection) {
   var mapLayers = [];
 
   layers.forEach(function (layer) {
-    if (layer instanceof _group2.default) {
+    if (layer instanceof _Group2.default) {
       Shared.getMapLayers(layer).forEach(function (l) {
         mapLayers.push(l);
       });
@@ -69,7 +67,7 @@ Shared.getMapLayers = function (collection) {
 };
 
 Shared.getLegendGraphicUrl = function (layer) {
-  if (layer.getSource() instanceof _tilewms2.default || layer.getSource() instanceof _imagewms2.default) {
+  if (layer.getSource() instanceof _TileWMS2.default || layer.getSource() instanceof _ImageWMS2.default) {
     var customParams = layer.get('customPrintLegendParams');
     var source = layer.getSource();
 
@@ -79,7 +77,7 @@ Shared.getLegendGraphicUrl = function (layer) {
         FORMAT = _source$getParams.FORMAT,
         passThroughParams = _objectWithoutProperties(_source$getParams, ['LAYERS', 'VERSION', 'FORMAT']);
 
-    var url = source instanceof _imagewms2.default ? source.getUrl() : source.getUrls()[0];
+    var url = source instanceof _ImageWMS2.default ? source.getUrl() : source.getUrls()[0];
     var params = _extends({
       LAYER: LAYERS.split(',')[0],
       VERSION: VERSION || '1.3.0',
@@ -97,7 +95,7 @@ Shared.getLegendGraphicUrl = function (layer) {
 
 Shared.getScaleForResolution = function (resolution, units) {
   var dpi = 25.4 / 0.28;
-  var mpu = _proj2.default.METERS_PER_UNIT[units];
+  var mpu = _Units.METERS_PER_UNIT[units];
   var inchesPerMeter = 39.37;
 
   return parseFloat(resolution) * mpu * inchesPerMeter * dpi;

--- a/src/serializer/VectorSerializer.js
+++ b/src/serializer/VectorSerializer.js
@@ -194,9 +194,7 @@ export class VectorSerializer extends BaseSerializer {
           // TODO not available in ol3?
           graphicYOffset: undefined,
           rotation: imageStyle.rotation,
-          // TODO Support full list of graphics: 'circle', 'square', 'star', 'x',
-          // 'cross' and 'triangle'
-          graphicName: 'circle'
+          graphicName: get(imageStyle, 'graphicName') || 'circle'
         };
         break;
       case 'LineString':
@@ -341,6 +339,44 @@ export class VectorSerializer extends BaseSerializer {
       return {};
     }
 
+    /**
+     * Returns the graphicName of a RegularShape or undefined based on the
+     * number of points, radius and angle.
+     *
+     * @returns {String | undefined} The graphicName of a RegularShape feature
+     *                                (triangle, square, cross, x and star)
+     */
+    const getGraphicName = () => {
+      if (olRegularShape.getPoints() === 3) {
+        return 'triangle';
+      }
+      else if (
+        olRegularShape.getPoints() === 4 &&
+        olRegularShape.getRadius2() === undefined
+      ) {
+        return 'square';
+      }
+      else if (
+        olRegularShape.getPoints() === 4 &&
+        olRegularShape.getRadius2() !== undefined &&
+        olRegularShape.getAngle() === 0
+      ) {
+        return 'cross';
+      }
+      else if (
+        olRegularShape.getPoints() === 4 &&
+        olRegularShape.getAngle() !== 0
+      ) {
+        return 'x';
+      }
+      else if (olRegularShape.getPoints() === 5) {
+        return 'star';
+      }
+      else {
+        return undefined;
+      }
+    };
+
     return {
       angle: olRegularShape.getAngle(),
       fill: this.writeFillStyle(olRegularShape.getFill()),
@@ -352,7 +388,8 @@ export class VectorSerializer extends BaseSerializer {
       rotation: olRegularShape.getRotation(),
       scale: olRegularShape.getScale(),
       snapToPixel: olRegularShape.getSnapToPixel(),
-      stroke: this.writeStrokeStyle(olRegularShape.getStroke())
+      stroke: this.writeStrokeStyle(olRegularShape.getStroke()),
+      graphicName: getGraphicName()
     };
   }
 


### PR DESCRIPTION
This MR updates the `VectorSerializer` from version` 2.0.0` to get the `graphicName` of a `RegularShape` (triangle, square, cross, x and star). 
Should be released afterwards as version 2.0.0-1, since version 2.0.1 already requires a newer OL version.

@terrestris/devs please review