### PR TITLE
Merge OpenLayers v5 branches together

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
     'node_modules/(?!ol)'
   ],
   setupFiles: [
+    'jest-canvas-mock',
     '<rootDir>/spec/jest/setup.js'
   ],
   collectCoverage: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terrestris/mapfish-print-manager",
-  "version": "5.1.0",
+  "version": "1.0.0-ol5",
   "description": "An interface to easily communicate with the MapFish Print module",
   "author": "terrestris GmbH & Co. KG <info@terrestris.de>",
   "contributors": [
@@ -61,7 +61,7 @@
     "babel-jest": "24.7.1",
     "babel-loader": "8.0.6",
     "babel-plugin-import": "1.12.0",
-    "canvas-prebuilt": "1.6.11",
+    "canvas": "2.6.0",
     "copy-webpack-plugin": "5.0.3",
     "documentation": "11.0.1",
     "eslint": "6.0.1",

--- a/src/interaction/InteractionTransform.js
+++ b/src/interaction/InteractionTransform.js
@@ -450,7 +450,7 @@ export class OlInteractionTransform extends OlInteractionPointer {
    * @param {ol.MapBrowserEvent} evt Map browser event.
    * @return {boolean} `true` to start the drag sequence.
    */
-  handleDownEvent = function(evt) {
+  handleDownEvent_ = function(evt) {
     var sel = this.getFeatureAtPixel_(evt.pixel);
     var feature = sel.feature;
 
@@ -501,7 +501,7 @@ export class OlInteractionTransform extends OlInteractionPointer {
   /**
    * @param {ol.MapBrowserEvent} evt Map browser event.
    */
-  handleDragEvent = function(evt) {
+  handleDragEvent_ = function(evt) {
     var geometry;
 
     switch (this.mode_) {
@@ -598,7 +598,7 @@ export class OlInteractionTransform extends OlInteractionPointer {
   /**
    * @param {ol.MapBrowserEvent} evt Event.
    */
-  handleMoveEvent = function(evt) {
+  handleMoveEvent_ = function(evt) {
     if (!this.mode_) {
       var sel = this.getFeatureAtPixel_(evt.pixel);
       var element = evt.map.getTargetElement();
@@ -623,7 +623,7 @@ export class OlInteractionTransform extends OlInteractionPointer {
   /**
    * @return {boolean} `false` to stop the drag sequence.
    */
-  handleUpEvent = function() {
+  handleUpEvent_ = function() {
     this.dispatchEvent({
       type: this.mode_ + 'end',
       feature: this.feature_,

--- a/src/manager/MapFishPrintV2Manager.js
+++ b/src/manager/MapFishPrintV2Manager.js
@@ -69,7 +69,11 @@ export class MapFishPrintV2Manager extends BaseMapFishPrintManager {
     this._layouts = this.capabilities.layouts;
     this._outputFormats = this.capabilities.outputFormats;
     this._dpis = this.capabilities.dpis;
-    this._scales = this.capabilities.scales;
+    if (this.customPrintScales.length > 0) {
+      this._scales = this.customPrintScales;
+    } else {
+      this._scales = this.capabilities.scales;
+    }
 
     this.setLayout(this.getLayouts()[0].name);
     this.setOutputFormat(this.getOutputFormats()[0].name);

--- a/src/serializer/MapFishPrintV2VectorSerializer.js
+++ b/src/serializer/MapFishPrintV2VectorSerializer.js
@@ -194,9 +194,7 @@ export class MapFishPrintV2VectorSerializer extends BaseSerializer {
           // TODO not available in ol3?
           graphicYOffset: undefined,
           rotation: imageStyle.rotation,
-          // TODO Support full list of graphics: 'circle', 'square', 'star', 'x',
-          // 'cross' and 'triangle'
-          graphicName: 'circle'
+          graphicName: get(imageStyle, 'graphicName') || 'circle'
         };
         break;
       case 'LineString':
@@ -341,6 +339,51 @@ export class MapFishPrintV2VectorSerializer extends BaseSerializer {
       return {};
     }
 
+    /**
+     * Returns the graphicName of a RegularShape or undefined based on the
+     * number of points, radius and angle.
+     *
+     * @returns {String | undefined} The graphicName of a RegularShape feature
+     *                                (triangle, square, cross, x and star)
+     */
+    const getGraphicName = () => {
+      if (olRegularShape.getPoints() === 3) {
+        return 'triangle';
+      }
+      else if (
+        olRegularShape.getPoints() === 4 &&
+        olRegularShape.getRadius2() === undefined
+      ) {
+        return 'square';
+      }
+      else if (
+        olRegularShape.getPoints() === 4 &&
+        olRegularShape.getRadius2() !== undefined &&
+        olRegularShape.getAngle() === 0
+      ) {
+        return 'cross';
+      }
+      else if (
+        olRegularShape.getPoints() === 4 &&
+        olRegularShape.getAngle() !== 0
+      ) {
+        return 'x';
+      }
+      else if (olRegularShape.getPoints() === 5) {
+        return 'star';
+      }
+      else {
+        return undefined;
+      }
+    };
+
+    const graphicName = getGraphicName();
+    let rotation = olRegularShape.getRotation();
+
+    if (graphicName === 'triangle') {
+      rotation = (rotation + 180) % 360;
+    }
+
     return {
       angle: olRegularShape.getAngle(),
       fill: this.writeFillStyle(olRegularShape.getFill()),
@@ -349,10 +392,11 @@ export class MapFishPrintV2VectorSerializer extends BaseSerializer {
       radius: olRegularShape.getRadius(),
       radius2: olRegularShape.getRadius2(),
       rotateWithView: olRegularShape.getRotateWithView(),
-      rotation: olRegularShape.getRotation(),
+      rotation,
       scale: olRegularShape.getScale(),
       snapToPixel: olRegularShape.getSnapToPixel(),
-      stroke: this.writeStrokeStyle(olRegularShape.getStroke())
+      stroke: this.writeStrokeStyle(olRegularShape.getStroke()),
+      graphicName
     };
   }
 


### PR DESCRIPTION
At the moment there are two branches [`ol5`](https://github.com/terrestris/mapfish-print-manager/tree/ol5) and [`v2.0.0-master`](https://github.com/terrestris/mapfish-print-manager/tree/v2.0.0-master) which are both based on OpenLayers v5.

This PR proposes to put changes from both branches together and merge them into `ol5` branch, which should be used in older ol5 based projects and maintained furthermore. After merge, the branch `v2.0.0-master` will be deleted.

It will be also proposed to publish a ol5 releases versions tagged as `x.x.x-ol5` (e.g. starting with `1.0.0-ol5`). For cleanliness and better traceability it could be useful to unpublish the already existing relases tagged with `v2.0.0-x` or at least mark them as deprecated or similar.

Please review @terrestris/devs 