### PR TITLE
Fix for OL5 branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "build:docs": "npm run clean:docs && documentation build -g -f html -o ./build/docs ./src/index.js",
     "prepublishOnly": "npm run build:dist && npm run build:docs",
     "release": "np --no-yarn --any-branch && git push https://github.com/terrestris/mapfish-print-manager.git master --tags",
-    "postpublish": "node ./tasks/update-gh-pages.js"
+    "postpublish": "node ./tasks/update-gh-pages.js",
+    "prepare": "npm run build:dist"
   },
   "dependencies": {
     "js-logger": "1.6.0",

--- a/spec/serializer/MapFishPrintV3GeoJsonSerializer.spec.js
+++ b/spec/serializer/MapFishPrintV3GeoJsonSerializer.spec.js
@@ -79,6 +79,7 @@ describe('MapFishPrintV3GeoJsonSerializer', () => {
             coordinates: [0, 0]
           },
           properties: {
+            _style: 0
           }
         }, {
           type: 'Feature',
@@ -87,6 +88,7 @@ describe('MapFishPrintV3GeoJsonSerializer', () => {
             coordinates: [[0, 0], [1, 1]]
           },
           properties: {
+            _style: 1
           }
         }, {
           type: 'Feature',
@@ -95,12 +97,37 @@ describe('MapFishPrintV3GeoJsonSerializer', () => {
             coordinates: [[[0, 0], [1, 1], [0, 0]]]
           },
           properties: {
+            _style: 2
           }
         }]
       },
       name: layer.get('name') || 'Vector Layer',
       opacity: layer.getOpacity(),
-      style: {},
+      style: {
+        0: {
+          fillColor: '#ffffff',
+          fillOpacity: 0.4,
+          graphicName: 'circle',
+          pointRadius: 5,
+          rotation: 0,
+          strokeColor: '#3399cc',
+          strokeOpacity: 1,
+          strokeWidth: 1.25,
+          version: 2,
+        },
+        1: {
+          strokeColor: '#3399cc',
+          strokeOpacity: 1,
+          strokeWidth: 1.25,
+        },
+        2: {
+          fillColor: '#ffffff',
+          fillOpacity: 0.4,
+          strokeColor: '#3399cc',
+          strokeOpacity: 1,
+          strokeWidth: 1.25,
+        }
+      },
       type: 'geojson'
     });
   });

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
+import { BaseMapFishPrintManager } from './manager/BaseMapFishPrintManager';
 import { MapFishPrintV2Manager } from './manager/MapFishPrintV2Manager';
 import { MapFishPrintV3Manager } from './manager/MapFishPrintV3Manager';
 
 export {
   MapFishPrintV2Manager,
-  MapFishPrintV3Manager
+  MapFishPrintV3Manager,
+  BaseMapFishPrintManager
 };

--- a/src/manager/MapFishPrintV3Manager.js
+++ b/src/manager/MapFishPrintV3Manager.js
@@ -250,7 +250,7 @@ export class MapFishPrintV3Manager extends BaseMapFishPrintManager {
    */
   getBasePath() {
     const baseUrlObj = new URL(this.url, null, QueryString.parse);
-    const baseHost = `${baseUrlObj.protocol}//${baseUrlObj.host}${baseUrlObj.port ? ':' + baseUrlObj.port : ''}${baseUrlObj.pathname}`;
+    const baseHost = `${baseUrlObj.protocol}//${baseUrlObj.host}${baseUrlObj.pathname}`;
     return baseHost;
   }
 

--- a/src/serializer/MapFishPrintV3GeoJsonSerializer.js
+++ b/src/serializer/MapFishPrintV3GeoJsonSerializer.js
@@ -3,6 +3,7 @@ import OlFormatGeoJSON from 'ol/format/GeoJSON';
 import OlStyleStyle from 'ol/style/Style';
 import OlStyleRegularShape from 'ol/style/RegularShape';
 import { fromCircle } from 'ol/geom/Polygon';
+import OlGeometryCircle from 'ol/geom/Circle';
 import OlFeature from 'ol/Feature';
 import OlStyleIcon from 'ol/style/Icon';
 import OlStyleCircle from 'ol/style/Circle';
@@ -32,13 +33,6 @@ export class MapFishPrintV3GeoJsonSerializer extends BaseSerializer {
    * @type {string}
    */
   static TYPE_GEOJSON = 'geojson';
-
-  /**
-   * The circle geometry type name.
-   *
-   * @type {string}
-   */
-  static CIRCLE_GEOMETRY_TYPE = 'Circle';
 
   /**
    * The property to get the style dictionary key from.
@@ -100,7 +94,7 @@ export class MapFishPrintV3GeoJsonSerializer extends BaseSerializer {
 
       // as GeoJSON format doesn't support circle geometries, we need to
       // transform circles to polygons.
-      if (geometryType === this.constructor.CIRCLE_GEOMETRY_TYPE) {
+      if (geometry instanceof OlGeometryCircle) {
         const style = feature.getStyle();
         const polyFeature = new OlFeature(fromCircle(geometry));
         polyFeature.setStyle(style);
@@ -142,13 +136,12 @@ export class MapFishPrintV3GeoJsonSerializer extends BaseSerializer {
           if (!serializedFeature.properties) {
             serializedFeature.properties = {};
           }
-          // serializedFeature.properties[this.constructor.FEAT_STYLE_PROPERTY] = styleName;
+          serializedFeature.properties[MapFishPrintV3GeoJsonSerializer.FEAT_STYLE_PROPERTY] = styleName;
         });
       }
     });
 
     const serialized = {
-      ...super.serialize(layer, opts, viewResolution),
       ...{
         geoJson: {
           type: 'FeatureCollection',
@@ -156,10 +149,8 @@ export class MapFishPrintV3GeoJsonSerializer extends BaseSerializer {
         },
         name: layer.get('name') || 'Vector Layer',
         opacity: layer.getOpacity(),
-        // TODO Currently not supported, GeoStyler MapFish JSON StyleParser should
-        // be used here!
-        style: {},
-        type: this.constructor.TYPE_GEOJSON
+        style: serializedStyles,
+        type: MapFishPrintV3GeoJsonSerializer.TYPE_GEOJSON
       },
       ...opts
     };


### PR DESCRIPTION
- Adds missing `BaseMapFishPrintManager` export
- Fixes `getBasePath`