### PR TITLE
New customDPIs property

### DIFF
--- a/src/manager/BaseMapFishPrintManager.js
+++ b/src/manager/BaseMapFishPrintManager.js
@@ -146,6 +146,14 @@ export class BaseMapFishPrintManager extends Observable {
   legendFilter = () => true;
 
   /**
+   * An array determining custom print Dpis. If provided, these will override
+   * the Dpis retrieved from print capabilities.
+   *
+   * @type {Array}
+   */
+  customDpis = [];
+
+  /**
    * An array determining custom print scales. If provided, these will override
    * the scales retrieved from print capabilities.
    *

--- a/src/manager/MapFishPrintV2Manager.js
+++ b/src/manager/MapFishPrintV2Manager.js
@@ -68,7 +68,7 @@ export class MapFishPrintV2Manager extends BaseMapFishPrintManager {
 
     this._layouts = this.capabilities.layouts;
     this._outputFormats = this.capabilities.outputFormats;
-    if(this.customDpis.length > 0) {
+    if (this.customDpis.length > 0) {
       this._dpis = this.customDpis;
     } else {
       this._dpis = this.capabilities.dpis;

--- a/src/manager/MapFishPrintV2Manager.js
+++ b/src/manager/MapFishPrintV2Manager.js
@@ -68,7 +68,11 @@ export class MapFishPrintV2Manager extends BaseMapFishPrintManager {
 
     this._layouts = this.capabilities.layouts;
     this._outputFormats = this.capabilities.outputFormats;
-    this._dpis = this.capabilities.dpis;
+    if(this.customDpis.length > 0) {
+      this._dpis = this.customDpis;
+    } else {
+      this._dpis = this.capabilities.dpis;
+    }
     if (this.customPrintScales.length > 0) {
       this._scales = this.customPrintScales;
     } else {

--- a/src/manager/MapFishPrintV3Manager.js
+++ b/src/manager/MapFishPrintV3Manager.js
@@ -479,12 +479,18 @@ export class MapFishPrintV3Manager extends BaseMapFishPrintManager {
     this._layout = layout;
 
     const mapAttribute = this.getAttributeByName('map');
-
-    this._dpis = get(mapAttribute, 'clientInfo.dpiSuggestions');
+    this._dpis = get(mapAttribute, 'clientInfo.dpiSuggestions')
+    
+    // if customDpis are given, use these instead
+    if(this.customDpis.length > 0) {
+      this._dpis = this.customDpis;
+    } 
+    
     // set some defaults if not provided via capabilities
     if (!this._dpis) {
       this._dpis = [72, 150];
     }
+
     this.setDpi(this.getDpis()[0]);
 
     this.setPrintMapSize({

--- a/src/manager/MapFishPrintV3Manager.js
+++ b/src/manager/MapFishPrintV3Manager.js
@@ -479,7 +479,7 @@ export class MapFishPrintV3Manager extends BaseMapFishPrintManager {
     this._layout = layout;
 
     const mapAttribute = this.getAttributeByName('map');
-    this._dpis = get(mapAttribute, 'clientInfo.dpiSuggestions')
+    this._dpis = get(mapAttribute, 'clientInfo.dpiSuggestions');
     
     // if customDpis are given, use these instead
     if(this.customDpis.length > 0) {

--- a/src/manager/MapFishPrintV3Manager.js
+++ b/src/manager/MapFishPrintV3Manager.js
@@ -482,7 +482,7 @@ export class MapFishPrintV3Manager extends BaseMapFishPrintManager {
     this._dpis = get(mapAttribute, 'clientInfo.dpiSuggestions');
     
     // if customDpis are given, use these instead
-    if(this.customDpis.length > 0) {
+    if (this.customDpis.length > 0) {
       this._dpis = this.customDpis;
     } 
     


### PR DESCRIPTION
This PR adds a new Property to `BaseMapFishPrintManager`, called `customDpis`.
It is intended for a user to use DPI values other than the ones in the capabilities or given as fallback in case the capabilities values do not exist.

`MapFishPrintV2Manager` and `MapFishPrintV3Manager` have also been slightly changed in order to consider this new property.

Please review @terrestris/devs 