### PR TITLE
fix: respect device pixel ratio when retrieving pixels from map

### DIFF
--- a/src/manager/BaseMapFishPrintManager.ts
+++ b/src/manager/BaseMapFishPrintManager.ts
@@ -13,6 +13,7 @@ import { fromExtent } from 'ol/geom/Polygon';
 import OlStyleStyle from 'ol/style/Style';
 import OlStyleFill from 'ol/style/Fill';
 import { Coordinate as OlCoordinate } from 'ol/coordinate';
+import {DEVICE_PIXEL_RATIO} from 'ol/has';
 
 import InteractionTransform, { OlInteractionTransformOpts } from '../interaction/InteractionTransform';
 
@@ -624,10 +625,10 @@ export class BaseMapFishPrintManager extends Observable {
       .getGeometry()
       .getCoordinates()[0];
 
-    const A = this.map.getPixelFromCoordinate(coords[1]);
-    const B = this.map.getPixelFromCoordinate(coords[4]);
-    const C = this.map.getPixelFromCoordinate(coords[3]);
-    const D = this.map.getPixelFromCoordinate(coords[2]);
+    const A = this.map.getPixelFromCoordinate(coords[1]).map(el => el * DEVICE_PIXEL_RATIO);
+    const B = this.map.getPixelFromCoordinate(coords[4]).map(el => el * DEVICE_PIXEL_RATIO);
+    const C = this.map.getPixelFromCoordinate(coords[3]).map(el => el * DEVICE_PIXEL_RATIO);
+    const D = this.map.getPixelFromCoordinate(coords[2]).map(el => el * DEVICE_PIXEL_RATIO);
 
     ctx.fillStyle = this.maskColor;
 


### PR DESCRIPTION
This takes the device pixel ratio into account when retrieving the pixels of the extent-geometry in order to draw the shadow mask on the canvas.

Before this change, when using a device with device pixel ratio != 1 like e.g. iPad, the mask would have a big offset and is not in sync with the extent-geometry .

Related discussion: https://github.com/openlayers/openlayers/issues/2904

To see the issue in action just watch the extent-geometry and the "shadow-mask" in a apple device emulator of your browser and pan the map.

@terrestris/devs please review
