### PR TITLE
Provide correct legendUrl value if none is set fro WMTS

### DIFF
--- a/src/manager/BaseMapFishPrintManager.ts
+++ b/src/manager/BaseMapFishPrintManager.ts
@@ -937,7 +937,11 @@ export class BaseMapFishPrintManager extends Observable {
           layer.get('name') ||
           (!(source instanceof OlSourceWMTS) && source.getParams().LAYERS) ||
           '',
-        icons: [Shared.getLegendGraphicUrl(layer)]
+        icons: [
+          Shared.getLegendGraphicUrl(layer) !== ''
+            ? Shared.getLegendGraphicUrl(layer)
+            : undefined
+        ]
       };
     }
   }


### PR DESCRIPTION
This PR sets the legendUrl to `undefined` when the string is empty. This is necessary because mapfish print couldn't find a legend under the previously submitted string.

@terrestris/devs please review