### PR TITLE
Actually filter out layers not visible at current scale

### DIFF
--- a/src/manager/BaseMapFishPrintManager.js
+++ b/src/manager/BaseMapFishPrintManager.js
@@ -608,7 +608,8 @@ export class BaseMapFishPrintManager extends Observable {
    * @return {boolean} Whether the layer should be printed or not.
    */
   filterPrintableLayer(layer) {
-    return layer !== this.extentLayer && layer.getVisible() && this.layerFilter(layer);
+    const res = Shared.getResolutionForScale(this.getScale(), 'm');
+    return layer !== this.extentLayer && layer.getVisible() && this.layerFilter(layer) && layer.get('minResolution') < res && layer.get('maxResolution') > res;
   }
 
   /**

--- a/src/util/Shared.js
+++ b/src/util/Shared.js
@@ -110,6 +110,15 @@ export class Shared {
 
     return parseFloat(resolution) * mpu * inchesPerMeter * dpi;
   }
+
+  static getResolutionForScale = (scale, units) => {
+    const dpi = 25.4 / 0.28;
+    const mpu = METERS_PER_UNIT[units];
+    const inchesPerMeter = 39.37;
+
+    return scale / (mpu * inchesPerMeter * dpi);
+  }
+
 }
 
 export default Shared;


### PR DESCRIPTION
Previously, layers not visible in the client due to scale constraints would still be printed.

@terrestris/devs Please review.