### PR TITLE
fix: dimension serialization for WMTS layers for Mapfish v3

### DIFF
--- a/spec/serializer/MapFishPrintV3WMTSSerializer.spec.ts
+++ b/spec/serializer/MapFishPrintV3WMTSSerializer.spec.ts
@@ -1,0 +1,137 @@
+import OlLayerTile from 'ol/layer/Tile';
+
+import { MapFishPrintV3WMTSSerializer } from '../../src/serializer/MapFishPrintV3WMTSSerializer';
+import OlSourceWMTS from 'ol/source/WMTS';
+import OlTileGridWMTS from 'ol/tilegrid/WMTS';
+
+describe('MapFishPrintV3WMTSSerializer', () => {
+  let serializer: MapFishPrintV3WMTSSerializer;
+
+  beforeEach(() => {
+    serializer = new MapFishPrintV3WMTSSerializer();
+  });
+
+  it('is defined', () => {
+    expect(MapFishPrintV3WMTSSerializer).not.toBeUndefined();
+  });
+
+  it('checks if the given layer can be serialized with it', () => {
+    const layer = new OlLayerTile({
+      source: new OlSourceWMTS({
+        layer: ' test',
+        matrixSet: undefined,
+        style: 'default',
+        tileGrid: undefined,
+      })
+    });
+
+    const serialized = serializer.serialize(layer);
+    expect(serialized).toBeUndefined();
+  });
+
+  it('serializes a layer with an WMTS source', () => {
+    const layerUrl = 'https://domain.com/wmts/{Layer}/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png';
+    const matrixSet = 'MATRIXSET';
+    const layer = new OlLayerTile({
+      extent: [-13884991, 2870341, -7455066, 6338219],
+      source: new OlSourceWMTS({
+        urls: [layerUrl],
+        layer: 'test',
+        matrixSet,
+        style: 'default',
+        tileGrid: new OlTileGridWMTS({
+          matrixIds: ['0'],
+          resolutions: [1000],
+          origin: [19, 0.9]
+        }),
+        requestEncoding: 'REST'
+      }),
+      properties: {
+        name: 'Peter'
+      }
+    });
+
+    const serializedSimple = serializer.serialize(layer);
+
+    expect(serializedSimple).toEqual({
+      baseURL: layerUrl,
+      customParams: undefined,
+      dimensionParams: {},
+      dimensions: undefined,
+      failOnError: true,
+      imageFormat: 'image/jpeg',
+      layer: 'test',
+      matrices: [{
+        identifier: '0',
+        matrixSize: [1, 1],
+        scaleDenominator: 3571428.571428572,
+        tileSize: [ 256, 256 ],
+        topLeftCorner: [ 19, 0.9 ],
+      }],
+      matrixSet,
+      mergeableParams: undefined,
+      name: 'Peter',
+      opacity: 1,
+      rasterStyle: '',
+      requestEncoding: 'REST',
+      style: 'default',
+      type: 'wmts',
+      version: '1.0.0',
+    });
+  });
+
+  it('accepts additional serializer dimension opts', () => {
+    const layerUrl = 'https://dim-wmts/{Time}/2056/{TileMatrix}/{TileCol}/{TileRow}.jpeg';
+    const layer = new OlLayerTile({
+      extent: [-13884991, 2870341, -7455066, 6338219],
+      source: new OlSourceWMTS({
+        urls: [layerUrl],
+        layer: 'test',
+        matrixSet: 'MATRIXSET',
+        style: 'default',
+        tileGrid: new OlTileGridWMTS({
+          matrixIds: ['0'],
+          resolutions: [1000],
+          origin: [19, 0.9]
+        }),
+        requestEncoding: 'REST',
+        dimensions: {
+          Time: 'current'
+        }
+      }),
+      properties: {
+        name: 'Peter'
+      }
+    });
+
+    const serializedSimple = serializer.serialize(layer);
+
+    expect(serializedSimple).toEqual({
+      baseURL: layerUrl,
+      customParams: undefined,
+      dimensionParams: {
+        Time: 'current'
+      },
+      dimensions: ['Time'],
+      failOnError: true,
+      imageFormat: 'image/jpeg',
+      layer: 'test',
+      matrices: [{
+        identifier: '0',
+        matrixSize: [1, 1],
+        scaleDenominator: 3571428.571428572,
+        tileSize: [ 256, 256 ],
+        topLeftCorner: [ 19, 0.9 ],
+      }],
+      matrixSet: 'MATRIXSET',
+      mergeableParams: undefined,
+      name: 'Peter',
+      opacity: 1,
+      rasterStyle: '',
+      requestEncoding: 'REST',
+      style: 'default',
+      type: 'wmts',
+      version: '1.0.0',
+    });
+  });
+});

--- a/src/serializer/MapFishPrintV3WMTSSerializer.ts
+++ b/src/serializer/MapFishPrintV3WMTSSerializer.ts
@@ -4,6 +4,7 @@ import OlLayer from 'ol/layer/Layer';
 import OlTileGridWMTS from 'ol/tilegrid/WMTS';
 
 import BaseSerializer from './BaseSerializer';
+import _isNil from 'lodash/isNil';
 
 export class MapFishPrintV3WMTSSerializer implements BaseSerializer {
 
@@ -43,14 +44,20 @@ export class MapFishPrintV3WMTSSerializer implements BaseSerializer {
       return;
     }
 
+    const dimensionParams = source.getDimensions();
+    let dimensions = undefined;
+    if (!_isNil(dimensionParams) && Object.keys(dimensionParams).length > 0) {
+      dimensions = Object.keys(dimensionParams);
+    }
+
     // 28mm is the pixel size
     const scaleDenominators = tileGrid.getResolutions().map(resolution => resolution / 0.00028);
-    const serialized = {
+    return {
       ...opts,
       baseURL: baseUrl,
       customParams: undefined,
-      dimensionParams: undefined,
-      dimensions: source.getDimensions(),
+      dimensionParams,
+      dimensions,
       failOnError: opts?.failOnError || true,
       imageFormat: source.getFormat() || 'image/png',
       layer: source.getLayer(),
@@ -73,8 +80,6 @@ export class MapFishPrintV3WMTSSerializer implements BaseSerializer {
       version: source.getVersion() || '1.1.0',
       type: MapFishPrintV3WMTSSerializer.TYPE_WMTS
     };
-
-    return serialized;
   }
 }
 


### PR DESCRIPTION
See title.

Serialized WMTS layers having dimension configuration (e.g. time) sould have the following structure in request payload:

```
…
dimensionParams: {
  Time: 'current'
},
dimensions: ['Time'],
…
```

For this (and the `MapFishPrintV3WMTSSerializer`) an test has been added as well.

Plz review @terrestris/devs 