### PR TITLE
Fix .releaserc channel for ol-8 releases

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -4,7 +4,7 @@
     {
       name: "ol-8",
       range: "11.x",
-      channel: "11.x
+      channel: "11.x"
     }
   ],
   "plugins": [


### PR DESCRIPTION
This PR fixes an error that occurred during `ol-8` release workflow (see also https://github.com/terrestris/mapfish-print-manager/actions/runs/8534353909/job/23378590177)

@terrestris/devs please review