### PR TITLE
Uses ol v9.1.0 and adjusts a version mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "jest-canvas-mock": "^2.4.0",
         "jest-environment-jsdom": "^29.3.1",
         "jest-fetch-mock": "^3.0.3",
-        "ol": "^9.0.0",
+        "ol": "^9.1.0",
         "rimraf": "^5.0.5",
         "semantic-release": "^23.0.6",
         "style-loader": "^3.3.4",
@@ -16034,9 +16034,9 @@
       "dev": true
     },
     "node_modules/ol": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-9.0.0.tgz",
-      "integrity": "sha512-+nYHZYbHrRUTDJ8ryxXPdDoAiaT6Zea02cocmGqsJXs4Oac1fYC9EbTIU2Y7803QcmG3u2MR88RxbksBvK+ZfQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-9.1.0.tgz",
+      "integrity": "sha512-nDrkJ2tzZNpo/wzN/PpHV5zdxbnXZaFktoMaD2cFLEc6gCwlgLY21Yd8wnt/4FjaVYwLBnbN9USXSwIBGcyksQ==",
       "dev": true,
       "dependencies": {
         "color-rgba": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "jest-canvas-mock": "^2.4.0",
     "jest-environment-jsdom": "^29.3.1",
     "jest-fetch-mock": "^3.0.3",
-    "ol": "^9.0.0",
+    "ol": "^9.1.0",
     "rimraf": "^5.0.5",
     "semantic-release": "^23.0.6",
     "style-loader": "^3.3.4",


### PR DESCRIPTION
With this PR ol is used in v9.1.0 and a mistake in the versioning is fixed as the use of ol9 should generate a new version 12 of mapfish-print-manager. In addition, some dependency updates will be integrated into the new version.

@terrestris/devs please review