### PR TITLE
fix: replace parse-css-font with css-font-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "16.0.1",
       "license": "MIT",
       "dependencies": {
+        "css-font-parser": "^2.0.1",
         "js-logger": "^1.6.1",
         "lodash": "^4.17.21",
         "parse-color": "^1.0.0",
-        "parse-css-font": "^4.0.0",
         "query-string": "^9.0.0",
         "url-parse": "^1.5.10"
       },
@@ -7947,35 +7947,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/css-font-size-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-font-size-keywords/-/css-font-size-keywords-1.0.0.tgz",
-      "integrity": "sha512-Q+svMDbMlelgCfH/RVDKtTDaf5021O486ZThQPIpahnIjUkMUslC+WuOQSWTgGSrNCH08Y7tYNEmmy0hkfMI8Q==",
-      "license": "MIT"
-    },
-    "node_modules/css-font-stretch-keywords": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/css-font-stretch-keywords/-/css-font-stretch-keywords-1.0.1.tgz",
-      "integrity": "sha512-KmugPO2BNqoyp9zmBIUGwt58UQSfyk1X5DbOlkb2pckDXFSAfjsD5wenb88fNrD6fvS+vu90a/tsPpb9vb0SLg==",
-      "license": "MIT"
-    },
-    "node_modules/css-font-style-keywords": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/css-font-style-keywords/-/css-font-style-keywords-1.0.1.tgz",
-      "integrity": "sha512-0Fn0aTpcDktnR1RzaBYorIxQily85M2KXRpzmxQPgh8pxUN9Fcn00I8u9I3grNr1QXVgCl9T5Imx0ZwKU973Vg==",
-      "license": "MIT"
-    },
-    "node_modules/css-font-weight-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-font-weight-keywords/-/css-font-weight-keywords-1.0.0.tgz",
-      "integrity": "sha512-5So8/NH+oDD+EzsnF4iaG4ZFHQ3vaViePkL1ZbZ5iC/KrsCY+WHq/lvOgrtmuOQ9pBBZ1ADGpaf+A4lj1Z9eYA==",
-      "license": "MIT"
-    },
-    "node_modules/css-list-helpers": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/css-list-helpers/-/css-list-helpers-2.0.0.tgz",
-      "integrity": "sha512-9Bj8tZ0jWbAM3u/U6m/boAzAwLPwtjzFvwivr2piSvyVa3K3rChJzQy4RIHkNkKiZCHrEMWDJWtTR8UyVhdDnQ==",
-      "license": "MIT"
+    "node_modules/css-font-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/css-font-parser/-/css-font-parser-2.0.1.tgz",
+      "integrity": "sha512-C4aQOpCmQL/Arl68chQatNh7/Nfyty15kbLNZezGudjcKSqHHVoHQEeb9IJcjgQ6CiurrHZoEt47yce891vjGw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/css-loader": {
       "version": "7.1.2",
@@ -8025,12 +8001,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/css-system-font-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz",
-      "integrity": "sha512-1umTtVd/fXS25ftfjB71eASCrYhilmEsvDEI6wG/QplnmlfmVM5HkZ/ZX46DT5K3eblFPgLUHt5BRCb0YXkSFA==",
-      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -18453,21 +18423,6 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
       "integrity": "sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling=="
     },
-    "node_modules/parse-css-font": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-css-font/-/parse-css-font-4.0.0.tgz",
-      "integrity": "sha512-lnY7dTUfjRXsSo5G5C639L8RaBBaVSgL+5hacIFKsNHzeCJQ5SFSZv1DZmc7+wZv/22PFGOq2YbaEHLdaCS/mQ==",
-      "license": "MIT",
-      "dependencies": {
-        "css-font-size-keywords": "^1.0.0",
-        "css-font-stretch-keywords": "^1.0.1",
-        "css-font-style-keywords": "^1.0.1",
-        "css-font-weight-keywords": "^1.0.0",
-        "css-list-helpers": "^2.0.0",
-        "css-system-font-keywords": "^1.0.0",
-        "unquote": "^1.1.1"
-      }
-    },
     "node_modules/parse-headers": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
@@ -22224,12 +22179,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/unquote": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
-      "integrity": "sha512-vRCqFv6UhXpWxZPyGDh/F3ZpNv8/qo7w6iufLpQg9aKnQ71qM4B5KiI7Mia9COcjEhrO9LueHpMYjYzsWH3OIg==",
-      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "license": "MIT",
   "author": "terrestris GmbH & Co. KG <info@terrestris.de>",
-  "type": "module",
   "contributors": [
     {
       "name": "Daniel Koch",
@@ -16,6 +15,7 @@
       "url": "https://github.com/dnlkoch"
     }
   ],
+  "type": "module",
   "main": "dist/index.js",
   "files": [
     "dist"
@@ -25,26 +25,26 @@
     "build:dist": "npm run clean:dist && tsc -p ./tsconfig.build.json",
     "build:docs": "npm run clean:docs && typedoc",
     "build:examples": "npm run clean:examples && webpack --config webpack.prod.cjs",
-    "clean": "npm run clean:dist && npm run clean:examples && npm run clean:docs",
     "check": "npm run typecheck && npm run lint && npm run test",
+    "clean": "npm run clean:dist && npm run clean:examples && npm run clean:docs",
     "clean:dist": "rimraf ./dist/*",
     "clean:docs": "rimraf ./build/docs/*",
     "clean:examples": "rimraf ./build/examples/*",
     "lint": "eslint -c eslint.config.mjs src/ spec/",
     "lint:fix": "npm run lint -- --fix",
-    "postpublish": "node ./tasks/update-gh-pages.cjs",
     "prepare": "husky",
     "prepublishOnly": "npm run build:dist && npm run build:docs",
+    "postpublish": "node ./tasks/update-gh-pages.cjs",
     "start": "webpack-dev-server --config webpack.dev.cjs",
     "test": "jest --maxWorkers=50% --coverage --config jest.config.cjs",
     "test:watch": "jest --watchAll --config jest.config.cjs",
     "typecheck": "tsc --pretty --noEmit"
   },
   "dependencies": {
+    "css-font-parser": "^2.0.1",
     "js-logger": "^1.6.1",
     "lodash": "^4.17.21",
     "parse-color": "^1.0.0",
-    "parse-css-font": "^4.0.0",
     "query-string": "^9.0.0",
     "url-parse": "^1.5.10"
   },
@@ -52,8 +52,8 @@
     "@babel/cli": "^7.25.7",
     "@babel/core": "^7.25.8",
     "@babel/eslint-parser": "^7.25.8",
-    "@babel/preset-env": "^7.25.8",
     "@babel/plugin-transform-class-properties": "^7.25.7",
+    "@babel/preset-env": "^7.25.8",
     "@babel/preset-typescript": "^7.25.7",
     "@commitlint/cli": "^19.0.1",
     "@commitlint/config-conventional": "^19.0.0",

--- a/spec/serializer/MapFishPrintV3GeoJsonSerializer.spec.ts
+++ b/spec/serializer/MapFishPrintV3GeoJsonSerializer.spec.ts
@@ -53,7 +53,6 @@ describe('MapFishPrintV3GeoJsonSerializer', () => {
   });
 
   it('serializes a layer with a Vector source (including features)', () => {
-
     const features: OlFeature<Geometry>[] = [
       new OlFeature({
         geometry: new OlGeomPoint([0, 0])

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -1,0 +1,14 @@
+declare module 'css-font-parser' {
+  export interface ParsedFont {
+    'font-family'?: string[];
+    'font-style'?: string;
+    'font-size'?: string;
+    'font-weight'?: string;
+    'font-variant'?: string;
+    'font-stretch'?: string;
+    'line-height'?: string;
+  };
+
+  function parseFont(font: string): ParsedFont | null;
+  function parseFontFamily(font: string): ParsedFont | null;
+};

--- a/src/serializer/MapFishPrintV2VectorSerializer.ts
+++ b/src/serializer/MapFishPrintV2VectorSerializer.ts
@@ -1,3 +1,4 @@
+import { parseFont } from 'css-font-parser';
 import get from 'lodash/get';
 import _isNil from 'lodash/isNil';
 import pickBy from 'lodash/pickBy';
@@ -18,12 +19,9 @@ import OlStyleStroke from 'ol/style/Stroke';
 import OlStyleStyle from 'ol/style/Style';
 import OlStyleText from 'ol/style/Text';
 
-
 import parseColor from 'parse-color';
-import parseFont, {IFont} from 'parse-css-font';
 
 import BaseSerializer from './BaseSerializer';
-
 
 export class MapFishPrintV2VectorSerializer implements BaseSerializer {
 
@@ -199,16 +197,16 @@ export class MapFishPrintV2VectorSerializer implements BaseSerializer {
     }
 
     if (textStyle && textStyle.text) {
-      const parsedFont = textStyle.font ? parseFont(textStyle.font) as IFont : undefined;
+      const parsedFont = textStyle.font ? parseFont(textStyle.font) : undefined;
       const fontColor = get(textStyle, 'fill.color') as string;
       style = {
         ...style,
         ...{
           label: textStyle.text,
-          fontFamily: parsedFont?.family?.join(','),
-          fontSize: parsedFont?.size,
-          fontWeight: parsedFont?.weight,
-          fontStyle: parsedFont?.style,
+          fontFamily: parsedFont?.['font-family']?.join(','),
+          fontSize: parsedFont?.['font-size'],
+          fontWeight: parsedFont?.['font-weight'],
+          fontStyle: parsedFont?.['font-style'],
           fontColor: parseColor(fontColor).hex,
           fontOpacity: get(parseColor(fontColor), 'rgba[3]')
         }

--- a/src/serializer/MapFishPrintV3GeoJsonSerializer.ts
+++ b/src/serializer/MapFishPrintV3GeoJsonSerializer.ts
@@ -1,3 +1,4 @@
+import { parseFont } from 'css-font-parser';
 import get from 'lodash/get';
 import _isNil from 'lodash/isNil';
 import pickBy from 'lodash/pickBy';
@@ -18,10 +19,8 @@ import OlStyleStroke from 'ol/style/Stroke';
 import OlStyleStyle from 'ol/style/Style';
 import OlStyleText from 'ol/style/Text';
 import parseColor from 'parse-color';
-import parseFont, { IFont } from 'parse-css-font';
 
 import BaseSerializer from './BaseSerializer';
-
 
 export class MapFishPrintV3GeoJsonSerializer implements BaseSerializer {
 
@@ -212,16 +211,17 @@ export class MapFishPrintV3GeoJsonSerializer implements BaseSerializer {
     }
 
     if (textStyle && textStyle.text) {
-      const parsedFont = textStyle.font ? parseFont(textStyle.font) as IFont : undefined;
+      const parsedFont = textStyle.font ? parseFont(textStyle.font) : undefined;
+
       const fontColor = get(textStyle, 'fill.color') as string;
       style = {
         ...style,
         ...{
           label: textStyle.text,
-          fontFamily: parsedFont?.family?.join(','),
-          fontSize: parsedFont?.size,
-          fontWeight: parsedFont?.weight,
-          fontStyle: parsedFont?.style,
+          fontFamily: parsedFont?.['font-family']?.join(','),
+          fontSize: parsedFont?.['font-size'],
+          fontWeight: parsedFont?.['font-weight'],
+          fontStyle: parsedFont?.['font-style'],
           fontColor: parseColor(fontColor).hex,
           fontOpacity: get(parseColor(fontColor), 'rgba[3]'),
           strokeOpacity: 0,


### PR DESCRIPTION
In some bundler configurations serializing a text style might lead to the following error:

`TypeError: systemFontKeywords.indexOf is not a function`

in the M2/M3 vector serializers.

This PR suggests to replace the `parse-css-font` with `css-font-parser` lib to fix this error (tested in the latest SHOGun gis client).

Please review @terrestris/devs.